### PR TITLE
Update libs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ if (localPropertiesFile.exists()) {
 
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+    throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -35,8 +35,8 @@ android {
     compileSdkVersion 33
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
@@ -48,7 +48,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "de.nucleus.foss_warn"
         minSdkVersion 23
         targetSdkVersion 33
@@ -67,19 +66,16 @@ android {
 
     buildTypes {
         debug {
-            useProguard false
             minifyEnabled false
             shrinkResources false
         }
 
         release {
-            // Signing with the release keys
-            // If you want to create your own release version for testing,
+            // to create your own release version for testing,
             // change .release to .debug or create your own signing key
             signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
-            useProguard false
         }
     }
 }
@@ -89,5 +85,5 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -15,6 +15,12 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            // to see deprecation warnings
+            //options.compilerArgs << "-Xlint:deprecation"
+        }
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,5 @@ org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
 extra-gen-snapshot-options=--obfuscate
-android.jetifier.blacklist=bcprov-jdk15on
+android.jetifier.ignorelist=bcprov-jdk15on
+android.enableR8.fullMode=true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -104,13 +104,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_background:
-    dependency: "direct main"
-    description:
-      name: flutter_background
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -218,7 +211,7 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.20"
+    version: "2.0.21"
   path_provider_ios:
     dependency: transitive
     description:
@@ -302,7 +295,7 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.2.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -440,7 +433,7 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.20"
+    version: "6.0.21"
   url_launcher_ios:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,10 +30,10 @@ dependencies:
   provider: ^6.0.4
   rxdart: ^0.27.5
   url_launcher: ^6.1.6
-  share_plus: ^6.1.0
+  share_plus: ^6.2.0
   app_settings: ^4.1.8
-  flutter_background: ^1.1.0
   android_alarm_manager_plus: ^2.1.0
+  #flutter_background: ^1.1.0
 
   # flutter_launcher_icons: ^0.9.2
 


### PR DESCRIPTION
Full changelog:

- update Android Gradle Plugin to 7.3.1
- replace `GradleException` with `FileNotFoundException` to fix `Could not find symbol 'GradleException'` error
- raise `sourceCompatibility` and `targetCompatibility` to Java 11
- remove deprecated `useProguard` command (now uses R8 by default which *significantly reduces the release file size*
- switch Kotlin implementation from `kotlin-stdlib-jdk7` to `kotlin-stdlib` (JDK 7 is not used in the project) 
- replace deprecated `android.jetifier.blacklist` with `android.jetifier.ignorelist`
- update Flutter dependencies
- added commented Gradle options to optionally show deprecation warnings (compile with -Xlint:deprecation)

---
The deprecation warnings right now are coming from `android_alarm_manager_plus`. I hope the devs will fix that "issues" at some time.