### PR TITLE
Ask for battery excemption using dialog

### DIFF
--- a/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
@@ -14,27 +14,29 @@ import android.os.PowerManager
 import android.provider.Settings
 
 class MainActivity: FlutterActivity() {
-    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+    private val CHANNEL = "flutter.native/helper"
+
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
         GeneratedPluginRegistrant.registerWith(flutterEngine)
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "flutter.native/helper").setMethodCallHandler {
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
                 call, result ->
-            when {
-                call.method.equals("showIgnoreBatteryOptimizationDialog") -> {
-                    val pm: PowerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
-                    val packageName: String = getApplicationContext().getPackageName()
-
-                    if (!pm.isIgnoringBatteryOptimizations(packageName)) {
-                        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
-                        intent.setData(Uri.parse("package:$packageName"))
-                        startActivity(intent)
-                    }
-                }
+            when (call.method) {
+                "showIgnoreBatteryOptimizationDialog" -> showIgnoreBatteryOptimizationDialog(result)
+                else -> result.notImplemented()
             }
         }
     }
 
     private fun showIgnoreBatteryOptimizationDialog(result: MethodChannel.Result) {
+        val pm: PowerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+        val packageName: String = getApplicationContext().getPackageName()
 
+        if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+            intent.setData(Uri.parse("package:$packageName"))
+            startActivity(intent)
+        }
     }
 }

--- a/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
@@ -18,7 +18,6 @@ class MainActivity: FlutterActivity() {
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-        GeneratedPluginRegistrant.registerWith(flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
                 call, result ->
             when (call.method) {

--- a/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
@@ -3,9 +3,38 @@ package de.nucleus.foss_warn
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugins.GeneratedPluginRegistrant
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+import android.net.Uri
+import android.content.Intent
+import android.os.Build
+import android.content.Context
+import android.os.PowerManager
+import android.provider.Settings
 
 class MainActivity: FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine) // add this line
+        GeneratedPluginRegistrant.registerWith(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "flutter.native/helper").setMethodCallHandler {
+                call, result ->
+            when {
+                call.method.equals("showIgnoreBatteryOptimizationDialog") -> {
+                    val pm: PowerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+                    val packageName: String = getApplicationContext().getPackageName()
+
+                    if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+                        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                        intent.setData(Uri.parse("package:$packageName"))
+                        startActivity(intent)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showIgnoreBatteryOptimizationDialog(result: MethodChannel.Result) {
+
     }
 }

--- a/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/nucleus/foss_warn/MainActivity.kt
@@ -5,7 +5,7 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugins.GeneratedPluginRegistrant
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-
+import androidx.annotation.NonNull
 import android.net.Uri
 import android.content.Intent
 import android.os.Build
@@ -19,17 +19,16 @@ class MainActivity: FlutterActivity() {
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         GeneratedPluginRegistrant.registerWith(flutterEngine)
-
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
                 call, result ->
             when (call.method) {
-                "showIgnoreBatteryOptimizationDialog" -> showIgnoreBatteryOptimizationDialog(result)
+                "showIgnoreBatteryOptimizationDialog" -> showIgnoreBatteryOptimizationDialog()
                 else -> result.notImplemented()
             }
         }
     }
 
-    private fun showIgnoreBatteryOptimizationDialog(result: MethodChannel.Result) {
+    private fun showIgnoreBatteryOptimizationDialog() {
         val pm: PowerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
         val packageName: String = getApplicationContext().getPackageName()
 

--- a/lib/views/WelcomeView.dart
+++ b/lib/views/WelcomeView.dart
@@ -17,6 +17,7 @@ class WelcomeView extends StatefulWidget {
 class _WelcomeViewState extends State<WelcomeView> {
   double currentPage = 0.0;
   final _pageViewController = new PageController();
+  final platform = const MethodChannel('flutter.native/helper');
 
   @override
   Widget build(BuildContext context) {
@@ -150,16 +151,14 @@ class _WelcomeViewState extends State<WelcomeView> {
               onPressed: () {
                 showDialog(
                   context: navigatorKey.currentContext!,
-                  builder: (BuildContext context) =>
-                      DisclaimerDialog(),
+                  builder: (BuildContext context) => DisclaimerDialog(),
                 );
               },
               child: Text(
                 "Haftungsausschluss",
                 style: TextStyle(color: Colors.white),
               ),
-              style:
-              TextButton.styleFrom(backgroundColor: Colors.blue),
+              style: TextButton.styleFrom(backgroundColor: Colors.blue),
             ),
             TextButton(
               onPressed: () {
@@ -172,8 +171,7 @@ class _WelcomeViewState extends State<WelcomeView> {
                 "Datenschutz",
                 style: TextStyle(color: Colors.white),
               ),
-              style:
-              TextButton.styleFrom(backgroundColor: Colors.blue),
+              style: TextButton.styleFrom(backgroundColor: Colors.blue),
             ),
           ],
         );
@@ -183,8 +181,6 @@ class _WelcomeViewState extends State<WelcomeView> {
   }
 
   Future<void> showIgnoreBatteryOptimizationDialog() async {
-    const platform = const MethodChannel('flutter.native/helper');
-
     try {
       await platform.invokeMethod("showIgnoreBatteryOptimizationDialog");
     } on PlatformException catch (e) {

--- a/lib/views/WelcomeView.dart
+++ b/lib/views/WelcomeView.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import '../services/welcomeScreenItems.dart';
-import 'package:app_settings/app_settings.dart';
 import '../main.dart';
 import 'SettingsView.dart';
 import '../services/saveAndLoadSharedPreferences.dart';
@@ -134,9 +134,7 @@ class _WelcomeViewState extends State<WelcomeView> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextButton(
-              onPressed: () {
-                AppSettings.openBatteryOptimizationSettings();
-              },
+              onPressed: () => showIgnoreBatteryOptimizationDialog(),
               child: Text(
                 "Akkuoptimerung ausschalten",
                 style: TextStyle(color: Colors.white),
@@ -181,6 +179,16 @@ class _WelcomeViewState extends State<WelcomeView> {
         );
       default:
         return SizedBox(height: 50);
+    }
+  }
+
+  Future<void> showIgnoreBatteryOptimizationDialog() async {
+    const platform = const MethodChannel('flutter.native/helper');
+
+    try {
+      await platform.invokeMethod("showIgnoreBatteryOptimizationDialog");
+    } on PlatformException catch (e) {
+      print(e);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,7 +288,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.5"
+    version: "0.27.6"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -496,7 +496,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,6 @@
 name: foss_warn
 description: Eine FOSS Umsetzung von NINA
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+publish_to: 'none'
 version: 0.4.5+24
 
 environment:
@@ -33,63 +19,26 @@ dependencies:
   share_plus: ^6.2.0
   app_settings: ^4.1.8
   android_alarm_manager_plus: ^2.1.0
+
   #flutter_background: ^1.1.0
-
   # flutter_launcher_icons: ^0.9.2
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  # cupertino_icons: ^1.0.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
 flutter_icons:
-  android: "app_icon"
-  ios: true
   image_path: "assets/app_icon.png"
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
+  android: true
+  ios: true
 
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # assets for the welcome screen
   assets:
+   # welcome screen
    - assets/app_icon.png
    - assets/location.png
    - assets/battery.png
    - assets/check.png
    - assets/steps.png
    - assets/paragraph.png
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   shared_preferences: ^2.0.15
   shared_preferences_android: ^2.0.14
   provider: ^6.0.4
-  rxdart: ^0.27.5
+  rxdart: ^0.27.6
   url_launcher: ^6.1.6
   share_plus: ^6.2.0
   app_settings: ^4.1.8


### PR DESCRIPTION
This makes the app ask for a battery excemption in the introduction using a dialog the user can allow/decline in the app.
The Android Project usually forbids the use of the needed permission for it.
But
1. we already use it (I think you added it for flutter_background)
2. AFAIK, it is not planned to release the app to the Play Store
3. the use case of this app should allow the usage because it is "safety app" - [Acceptable use cases for excemption](https://developer.android.com/training/monitoring-device-state/doze-standby#exemption-cases)