### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/lib/class/class_userPreferences.dart
+++ b/lib/class/class_userPreferences.dart
@@ -26,7 +26,7 @@ class UserPreferences {
   bool showAllWarnings = false;
   bool areWarningsFromCache = false;
 
-  String versionNumber = "0.6.0-alpha_3 "; // shown in the about view
+  String versionNumber = "0.6.0"; // shown in the about view
 
   bool activateAlertSwiss = false;
   bool isFirstStart = true;

--- a/lib/widgets/dialogs/ChangeLogDialog.dart
+++ b/lib/widgets/dialogs/ChangeLogDialog.dart
@@ -18,10 +18,10 @@ class ChangeLogDialog extends StatelessWidget {
                 style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
               ),
               Text("* Der Code ist jetzt neu strukturiert und besser organisiert\n"
-                   "* Die Daten werden jetzt intern bessern verwaltet, dadurch müssen die Einstellungen und Orte neu eingestellt werden.¸\n"
+                   "* Die Daten werden jetzt intern besser verwaltet, dadurch müssen die Einstellungen und Orte neu eingestellt werden.\n"
                    "* Die Sortierung funktioniert jetzt wieder wie erwartet \n"
-                   "* Die App stürzt jetzt bei einem Neustart nicht mehr ab \n"
-                   "* Das Erkennen von Telefonnummern funktioniert jetzt zuverlässiger \n"
+                   "* Die App stürzt jetzt bei einem Systemneustart nicht mehr ab. \n"
+                   "* Das Erkennen von Telefonnummern funktioniert jetzt zuverlässiger. \n"
                    "* sonstige Fehlerbehebungen \n"),
               Text(
                 "0.5.1 (beta)",

--- a/lib/widgets/dialogs/ChangeLogDialog.dart
+++ b/lib/widgets/dialogs/ChangeLogDialog.dart
@@ -14,6 +14,16 @@ class ChangeLogDialog extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
+                "0.6.0 (beta)",
+                style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+              ),
+              Text("* Der Code ist jetzt neu strukturiert und besser organisiert\n"
+                   "* Die Daten werden jetzt intern bessern verwaltet, dadurch müssen die Einstellungen und Orte neu eingestellt werden.¸\n"
+                   "* Die Sortierung funktioniert jetzt wieder wie erwartet \n"
+                   "* Die App stürzt jetzt bei einem Neustart nicht mehr ab \n"
+                   "* Das Erkennen von Telefonnummern funktioniert jetzt zuverlässiger \n"
+                   "* sonstige Fehlerbehebungen \n"),
+              Text(
                 "0.5.1 (beta)",
                 style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
               ),

--- a/lib/widgets/dialogs/legacyWarningDialog.dart
+++ b/lib/widgets/dialogs/legacyWarningDialog.dart
@@ -13,19 +13,13 @@ class _LegacyWarningDialogState extends State<LegacyWarningDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text("Updated version to ${userPreferences.versionNumber}"),
+      title: Text("${AppLocalizations.of(context)!.legacy_warning_dialog_title} ${userPreferences.versionNumber}"),
       content: Container(
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                  "FOSSWarn is now updated to a new version."
-                      " With this new version we have improved the internal "
-                      "structure of the app. Externally there is no big change,"
-                      " but we had to reset all settings and saved locations."
-                      " Please check your settings and add your places again. "
-                      "\n\nThank you for your understanding and sorry for the inconvenience.")
+            children: [ //
+              Text(AppLocalizations.of(context)!.legacy_warning_dialog_text)
             ],
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: foss_warn
 description: Eine FOSS Umsetzung von NINA
 publish_to: 'none'
-version: 0.5.1+27
+version: 0.6.0+28
 
 environment:
   sdk: ">=2.17.0 <3.13.3"


### PR DESCRIPTION
- add changelog for 0.6.0
- increase version number
- use new translation strings (added in https://github.com/nucleus-ffm/foss_warn/pull/96)