### PR TITLE
Fix geojson parsing error and improve wording

### DIFF
--- a/lib/class/class_Area.dart
+++ b/lib/class/class_Area.dart
@@ -269,7 +269,7 @@ class Area {
       return result;
     } catch (e) {
       ErrorLogger.writeErrorLog(
-          "MapWidget", "Error while parsing geoJson", e.toString());
+          "class_Area.dart", "Error while parsing geoJson", e.toString());
       appState.error = true;
       return [];
     }

--- a/lib/class/class_ErrorLogger.dart
+++ b/lib/class/class_ErrorLogger.dart
@@ -37,9 +37,9 @@ class ErrorLogger {
       // Read the file
       return await file.readAsString();
     } catch (e) {
-      // If encountering an error, return 0
+      // If encountering an error, then there is no log file yet
       print("Error while reading logfile: ${e.toString()}");
-      return "Error. Can not read logfile.";
+      return "No log to read.";
     }
   }
 

--- a/lib/services/apiHandler.dart
+++ b/lib/services/apiHandler.dart
@@ -258,6 +258,15 @@ Future<List<WarnMessage>> parseNinaJsonData(
 
       String geoJson = geoJsonRaw.toString();
 
+      //@todo find a cleaner solution later
+      // geoJson from dwd can contain coordinates that are no doubles.
+      // This results in an error when we try to convert it to a geoJson object
+      // therefore, we replace every int coordinate with a double representation
+      // of it by just adding .0
+      geoJson = geoJson.replaceAllMapped(RegExp(r'\[\d+\,'), (Match m) => "[${m.group(0)?.replaceAll("[", "").replaceAll(",", "")}.0,");
+      geoJson = geoJson.replaceAllMapped(RegExp(r'\s\d+]'), (Match m) => "${m.group(0)?.replaceAll("]", "").replaceAll(",", "")}.0]");
+
+
       var warningDetails = jsonDecode(utf8.decode(responseDetails.bodyBytes));
       // create the new WarnMessage
       WarnMessage? temp = createWarning(warningDetails, provider, geoJson);

--- a/lib/widgets/dialogs/legacyWarningDialog.dart
+++ b/lib/widgets/dialogs/legacyWarningDialog.dart
@@ -79,13 +79,13 @@ class _LegacyWarningDialogState extends State<LegacyWarningDialog> {
                 if (!foundPlace) {
                   LoadingScreen.instance().show(
                       context: context,
-                      text: "No replacement was found for ${p.name}");
+                      text: "No replacement was found for ${p.name}. Please add the place again manually.");
                   await Future.delayed(const Duration(seconds: 2));
                 }
               }
               // sve new list
               LoadingScreen.instance()
-                  .show(context: context, text: "Done. saving new places");
+                  .show(context: context, text: "Done.");
               tempList.clear();
               // save new list
               saveMyPlacesList();


### PR DESCRIPTION
- alerts from DWD sometimes contain coordinates that are not doubles but ints. This causes parsing errors. We now convert every int into a double representation to avoid this error
- this PR improves some wording to avoid misunderstandings