### PR TITLE
refactor: make DetailScreen not require any arguments to be passed

### DIFF
--- a/lib/class/abstract_place.dart
+++ b/lib/class/abstract_place.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_notification_preferences.dart';
 import 'package:foss_warn/enums/warning_source.dart';
 import 'package:foss_warn/services/save_and_load_shared_preferences.dart';
-import 'package:provider/provider.dart';
 
 import '../enums/severity.dart';
 import '../main.dart';
@@ -110,13 +110,13 @@ abstract class Place {
 
   /// set the read status from all warnings to true
   /// @context to update view
-  void markAllWarningsAsRead(BuildContext context) {
+  void markAllWarningsAsRead(WidgetRef ref) {
     for (WarnMessage myWarnMessage in _warnings) {
       myWarnMessage.read = true;
       NotificationService.cancelOneNotification(
           myWarnMessage.identifier.hashCode);
     }
-    final updater = Provider.of<Update>(context, listen: false);
+    final updater = ref.read(updaterProvider);
     updater.updateReadStatusInList();
     saveMyPlacesList();
   }
@@ -124,12 +124,12 @@ abstract class Place {
   /// set the read and notified status from all warnings to false
   /// used for debug purpose
   /// [@context] to update view
-  void resetReadAndNotificationStatusForAllWarnings(BuildContext context) {
+  void resetReadAndNotificationStatusForAllWarnings(WidgetRef ref) {
     for (WarnMessage myWarnMessage in _warnings) {
       myWarnMessage.read = false;
       myWarnMessage.notified = false;
     }
-    final updater = Provider.of<Update>(context, listen: false);
+    final updater = ref.read(updaterProvider);
     updater.updateReadStatusInList();
     saveMyPlacesList();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,28 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:foss_warn/class/class_unified_push_handler.dart';
 import 'package:foss_warn/class/class_user_preferences.dart';
-import 'package:foss_warn/services/geocode_handler.dart';
 import 'package:foss_warn/services/legacy_handler.dart';
-import 'package:foss_warn/services/list_handler.dart';
-import 'package:foss_warn/views/about_view.dart';
-import 'package:foss_warn/views/map_view.dart';
+import 'package:foss_warn/views/home_view.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:unifiedpush/unifiedpush.dart';
 
-import 'class/abstract_place.dart';
 import 'class/class_app_state.dart';
-import 'views/my_places_view.dart';
-import 'views/settings_view.dart';
-import 'views/all_warnings_view.dart';
 import 'views/welcome_view.dart';
 
 import 'class/class_notification_service.dart';
 
-import 'services/update_provider.dart';
 import 'services/save_and_load_shared_preferences.dart';
-
-import 'widgets/dialogs/sort_by_dialog.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 final AppState appState = AppState();
@@ -55,152 +43,5 @@ class FOSSWarn extends StatelessWidget {
         home: userPreferences.showWelcomeScreen ? WelcomeView() : HomeView(),
       ),
     );
-  }
-}
-
-class HomeView extends ConsumerStatefulWidget {
-  const HomeView({super.key});
-
-  @override
-  ConsumerState<HomeView> createState() => _HomeViewState();
-}
-
-class _HomeViewState extends ConsumerState<HomeView> {
-  int _selectedIndex = userPreferences.startScreen; // selected start view
-
-  // list of views for the navigation bar
-  final List<Widget> _pages = <Widget>[
-    AllWarningsView(),
-    MyPlaces(),
-    MapView()
-  ];
-
-  @override
-  void initState() {
-    super.initState();
-
-    // init unified push
-    UnifiedPush.initialize(
-      onNewEndpoint: UnifiedPushHandler
-          .onNewEndpoint, // takes (String endpoint, String instance) in args
-      onRegistrationFailed:
-          UnifiedPushHandler.onRegistrationFailed, // takes (String instance)
-      onUnregistered:
-          UnifiedPushHandler.onUnregistered, // takes (String instance)
-      onMessage: UnifiedPushHandler
-          .onMessage, // takes (Uint8List message, String instance) in args
-    );
-
-    loadMyPlacesList();
-    listenNotifications();
-    if (geocodeMap.isEmpty) {
-      debugPrint("call geocode handler");
-      geocodeHandler();
-    }
-    //display information if the app had to be resetted
-    showMigrationDialog(context);
-  }
-
-  void listenNotifications() {
-    NotificationService.onNotification.stream.listen(onClickedNotification);
-  }
-
-  void onClickedNotification(String? payload) {
-    //change view to "MyPlaces"
-    setState(() {
-      _selectedIndex = 1;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    var updater = ref.read(updaterProvider);
-
-    return Scaffold(
-        // set to false to prevent the widget from jumping after closing the keyboard
-        resizeToAvoidBottomInset: false,
-        appBar: AppBar(
-          title: Text("FOSS Warn"),
-          actions: [
-            IconButton(
-              icon: Icon(Icons.sort),
-              tooltip: AppLocalizations.of(context)!
-                  .main_app_bar_action_sort_tooltip,
-              onPressed: () {
-                showDialog(
-                  context: context,
-                  builder: (BuildContext context) => SortByDialog(),
-                );
-                updater.updateReadStatusInList();
-              },
-            ),
-            IconButton(
-              onPressed: () {
-                for (Place p in myPlaceList) {
-                  p.markAllWarningsAsRead(ref);
-                }
-                final snackBar = SnackBar(
-                  content: Text(
-                    AppLocalizations.of(context)!
-                        .main_app_bar_tooltip_mark_all_warnings_as_read,
-                  ),
-                );
-
-                // Find the ScaffoldMessenger in the widget tree
-                // and use it to show a SnackBar.
-                ScaffoldMessenger.of(context).showSnackBar(snackBar);
-              },
-              icon: Icon(Icons.mark_chat_read),
-              tooltip: AppLocalizations.of(context)!
-                  .main_app_bar_tooltip_mark_all_warnings_as_read,
-            ),
-            PopupMenuButton(
-                icon: Icon(Icons.more_vert),
-                onSelected: (result) {
-                  switch (result) {
-                    case 0:
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => Settings()),
-                      );
-                      break;
-                    case 1:
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => AboutView()),
-                      );
-                      break;
-                  }
-                },
-                itemBuilder: (context) => <PopupMenuEntry>[
-                      PopupMenuItem(
-                          value: 0,
-                          child: Text(AppLocalizations.of(context)!
-                              .main_dot_menu_settings)),
-                      PopupMenuItem(
-                          value: 1,
-                          child: Text(AppLocalizations.of(context)!
-                              .main_dot_menu_about))
-                    ])
-          ],
-        ),
-        bottomNavigationBar: NavigationBar(
-          destinations: <NavigationDestination>[
-            NavigationDestination(
-                icon: Icon(Icons.warning),
-                label: AppLocalizations.of(context)!.main_nav_bar_all_warnings),
-            NavigationDestination(
-                icon: Icon(Icons.place),
-                label: AppLocalizations.of(context)!.main_nav_bar_my_places),
-            NavigationDestination(icon: Icon(Icons.map), label: "Map")
-          ],
-          onDestinationSelected: (int index) {
-            setState(() {
-              _selectedIndex = index;
-            });
-          },
-          selectedIndex: _selectedIndex,
-        ),
-        body: _pages.elementAt(_selectedIndex));
   }
 }

--- a/lib/services/update_provider.dart
+++ b/lib/services/update_provider.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/services/api_handler.dart';
 import '../class/abstract_place.dart';
 import 'save_and_load_shared_preferences.dart';
 import 'list_handler.dart';
+
+final updaterProvider = Provider((ref) => Update());
 
 class Update with ChangeNotifier {
   // delete preset

--- a/lib/services/warning.dart
+++ b/lib/services/warning.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:foss_warn/class/abstract_place.dart';
+import 'package:foss_warn/class/class_warn_message.dart';
+
+final currentWarningProvider = StateProvider<ActiveWarning?>((ref) => null);
+
+class ActiveWarning {
+  final WarnMessage message;
+  final Place? place;
+
+  const ActiveWarning({
+    required this.message,
+    required this.place,
+  });
+}

--- a/lib/views/add_my_place_view.dart
+++ b/lib/views/add_my_place_view.dart
@@ -1,24 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../class/abstract_place.dart';
 import '../class/class_notification_service.dart';
 import '../services/list_handler.dart';
 import '../services/update_provider.dart';
 
-class AddMyPlaceView extends StatefulWidget {
+class AddMyPlaceView extends ConsumerStatefulWidget {
   const AddMyPlaceView({super.key});
 
   @override
-  State<AddMyPlaceView> createState() => _AddMyPlaceViewState();
+  ConsumerState<AddMyPlaceView> createState() => _AddMyPlaceViewState();
 }
 
-class _AddMyPlaceViewState extends State<AddMyPlaceView> {
+class _AddMyPlaceViewState extends ConsumerState<AddMyPlaceView> {
   List<Place> _allPlacesToShow = [];
 
   @override
   Widget build(BuildContext context) {
+    var updater = ref.read(updaterProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.add_new_place),
@@ -59,8 +61,6 @@ class _AddMyPlaceViewState extends State<AddMyPlaceView> {
                             style: Theme.of(context).textTheme.titleMedium),
                         onTap: () {
                           setState(() {
-                            final updater =
-                                Provider.of<Update>(context, listen: false);
                             updater.updateList(place);
                             // cancel warning of missing places (ID: 3)
                             NotificationService.cancelOneNotification(3);

--- a/lib/views/add_my_place_with_map_view.dart
+++ b/lib/views/add_my_place_with_map_view.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_bounding_box.dart';
 import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/class/class_fpas_place.dart';
@@ -13,23 +14,22 @@ import 'package:foss_warn/widgets/map_widget.dart';
 import 'package:http/http.dart';
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
-import 'package:provider/provider.dart';
 
 import '../class/abstract_place.dart';
 import '../class/class_notification_service.dart';
 import '../class/class_unified_push_handler.dart';
 import '../services/update_provider.dart';
-// import '../widgets/VectorMapWidget.dart';
 import '../widgets/dialogs/loading_screen.dart';
 
-class AddMyPlaceWithMapView extends StatefulWidget {
+class AddMyPlaceWithMapView extends ConsumerStatefulWidget {
   const AddMyPlaceWithMapView({super.key});
 
   @override
-  State<AddMyPlaceWithMapView> createState() => _AddMyPlaceWithMapViewState();
+  ConsumerState<AddMyPlaceWithMapView> createState() =>
+      _AddMyPlaceWithMapViewState();
 }
 
-class _AddMyPlaceWithMapViewState extends State<AddMyPlaceWithMapView> {
+class _AddMyPlaceWithMapViewState extends ConsumerState<AddMyPlaceWithMapView> {
   final MapController mapController = MapController();
   final TextEditingController textEditingController = TextEditingController();
   final FocusNode textInputFocus = FocusNode();
@@ -182,6 +182,8 @@ class _AddMyPlaceWithMapViewState extends State<AddMyPlaceWithMapView> {
 
   @override
   Widget build(BuildContext context) {
+    var updater = ref.read(updaterProvider);
+
     return Scaffold(
       // set to false to prevent jumping of the radiusSlider Widget
       resizeToAvoidBottomInset: false,
@@ -466,8 +468,6 @@ class _AddMyPlaceWithMapViewState extends State<AddMyPlaceWithMapView> {
                                       name: _selectedPlaceName);
 
                                   setState(() {
-                                    final updater = Provider.of<Update>(context,
-                                        listen: false);
                                     updater.updateList(newPlace);
                                     // cancel warning of missing places (ID: 3)
                                     NotificationService.cancelOneNotification(

--- a/lib/views/all_warnings_view.dart
+++ b/lib/views/all_warnings_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/api_handler.dart';
 import '../services/check_for_my_places_warnings.dart';
@@ -14,14 +14,14 @@ import '../services/sort_warnings.dart';
 import '../services/update_provider.dart';
 import '../widgets/no_warnings_in_list.dart';
 
-class AllWarningsView extends StatefulWidget {
+class AllWarningsView extends ConsumerStatefulWidget {
   const AllWarningsView({super.key});
 
   @override
-  State<AllWarningsView> createState() => _AllWarningsViewState();
+  ConsumerState<AllWarningsView> createState() => _AllWarningsViewState();
 }
 
-class _AllWarningsViewState extends State<AllWarningsView> {
+class _AllWarningsViewState extends ConsumerState<AllWarningsView> {
   bool _loading = false;
   @override
   void initState() {
@@ -39,6 +39,8 @@ class _AllWarningsViewState extends State<AllWarningsView> {
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(updaterProvider); // Just to rebuild on updates
+
     Future<void> reloadData() async {
       setState(() {
         _loading = true;
@@ -90,125 +92,121 @@ class _AllWarningsViewState extends State<AllWarningsView> {
       return warningsForMyPlaces;
     }
 
-    return Consumer<Update>(
-      builder: (context, counter, child) => RefreshIndicator(
-        color: Theme.of(context).colorScheme.secondary,
-        onRefresh: reloadData,
-        child: myPlaceList.isNotEmpty // check if there is a place saved
-            ? userPreferences
-                    .showAllWarnings // if warnings that are not in MyPlaces shown
-                ? SingleChildScrollView(
-                    physics: AlwaysScrollableScrollPhysics(),
-                    child: Column(children: [
-                      ConnectionError(),
-                      mapWarningsList.isEmpty ? NoWarningsInList() : SizedBox(),
-                      ...mapWarningsList.map((warnMessage) => WarningWidget(
-                          warnMessage: warnMessage, isMyPlaceWarning: false)),
-                    ]))
-                // else load only the warnings for my place
-                : loadOnlyWarningsForMyPlaces() //
-                        .isNotEmpty // check if there are warnings for myPlaces
-                    ? SingleChildScrollView(
-                        physics: AlwaysScrollableScrollPhysics(),
-                        child:
-                            Column(mainAxisSize: MainAxisSize.max, children: [
-                          ConnectionError(),
-                          ...loadOnlyWarningsForMyPlaces()
-                              .map((warnMessage) => WarningWidget(
-                                    warnMessage: warnMessage,
-                                    isMyPlaceWarning: true,
-                                  )),
-                        ]),
-                      )
-                    : Column(
-                        // else show a screen with
-                        mainAxisSize: MainAxisSize.max,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Expanded(
-                            child: Center(
-                              child: Padding(
-                                padding: const EdgeInsets.all(12.0),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                        AppLocalizations.of(context)!
-                                            .all_warnings_everything_ok,
-                                        style: TextStyle(
-                                            fontSize: 25,
-                                            fontWeight: FontWeight.bold)),
-                                    Icon(
-                                      Icons.check_circle_rounded,
-                                      size: 200,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .secondary,
-                                    ),
-                                    Text(AppLocalizations.of(context)!
-                                        .all_warnings_everything_ok_text),
-                                    SizedBox(height: 10),
-                                    TextButton(
-                                      onPressed: () {
-                                        setState(() {
-                                          _loading = true;
-                                        });
-                                      },
-                                      style: TextButton.styleFrom(
-                                          backgroundColor: Theme.of(context)
+    return RefreshIndicator(
+      color: Theme.of(context).colorScheme.secondary,
+      onRefresh: reloadData,
+      child: myPlaceList.isNotEmpty // check if there is a place saved
+          ? userPreferences
+                  .showAllWarnings // if warnings that are not in MyPlaces shown
+              ? SingleChildScrollView(
+                  physics: AlwaysScrollableScrollPhysics(),
+                  child: Column(children: [
+                    ConnectionError(),
+                    mapWarningsList.isEmpty ? NoWarningsInList() : SizedBox(),
+                    ...mapWarningsList.map((warnMessage) => WarningWidget(
+                        warnMessage: warnMessage, isMyPlaceWarning: false)),
+                  ]))
+              // else load only the warnings for my place
+              : loadOnlyWarningsForMyPlaces() //
+                      .isNotEmpty // check if there are warnings for myPlaces
+                  ? SingleChildScrollView(
+                      physics: AlwaysScrollableScrollPhysics(),
+                      child: Column(mainAxisSize: MainAxisSize.max, children: [
+                        ConnectionError(),
+                        ...loadOnlyWarningsForMyPlaces()
+                            .map((warnMessage) => WarningWidget(
+                                  warnMessage: warnMessage,
+                                  isMyPlaceWarning: true,
+                                )),
+                      ]),
+                    )
+                  : Column(
+                      // else show a screen with
+                      mainAxisSize: MainAxisSize.max,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Expanded(
+                          child: Center(
+                            child: Padding(
+                              padding: const EdgeInsets.all(12.0),
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Text(
+                                      AppLocalizations.of(context)!
+                                          .all_warnings_everything_ok,
+                                      style: TextStyle(
+                                          fontSize: 25,
+                                          fontWeight: FontWeight.bold)),
+                                  Icon(
+                                    Icons.check_circle_rounded,
+                                    size: 200,
+                                    color:
+                                        Theme.of(context).colorScheme.secondary,
+                                  ),
+                                  Text(AppLocalizations.of(context)!
+                                      .all_warnings_everything_ok_text),
+                                  SizedBox(height: 10),
+                                  TextButton(
+                                    onPressed: () {
+                                      setState(() {
+                                        _loading = true;
+                                      });
+                                    },
+                                    style: TextButton.styleFrom(
+                                        backgroundColor: Theme.of(context)
+                                            .colorScheme
+                                            .secondary),
+                                    child: Text(
+                                      AppLocalizations.of(context)!
+                                          .all_warnings_reload,
+                                      style: TextStyle(
+                                          color: Theme.of(context)
                                               .colorScheme
-                                              .secondary),
-                                      child: Text(
-                                        AppLocalizations.of(context)!
-                                            .all_warnings_reload,
-                                        style: TextStyle(
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .onSecondary),
-                                      ),
-                                    )
-                                  ],
-                                ),
+                                              .onSecondary),
+                                    ),
+                                  )
+                                ],
                               ),
                             ),
                           ),
-                        ],
-                      )
-            : Column(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      ConnectionError(),
-                    ],
-                  ),
-                  Expanded(
-                    child: Center(
-                      child: Padding(
-                        padding: const EdgeInsets.all(12.0),
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                                AppLocalizations.of(context)!
-                                    .all_warnings_no_places_chosen,
-                                style: TextStyle(
-                                    fontSize: 18, fontWeight: FontWeight.bold)),
-                            Text("\n"),
-                            Text(AppLocalizations.of(context)!
-                                .all_warnings_no_places_chosen_text),
-                          ],
                         ),
+                      ],
+                    )
+          : Column(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ConnectionError(),
+                  ],
+                ),
+                Expanded(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                              AppLocalizations.of(context)!
+                                  .all_warnings_no_places_chosen,
+                              style: TextStyle(
+                                  fontSize: 18, fontWeight: FontWeight.bold)),
+                          Text("\n"),
+                          Text(AppLocalizations.of(context)!
+                              .all_warnings_no_places_chosen_text),
+                        ],
                       ),
                     ),
-                  )
-                ],
-              ),
-      ),
+                  ),
+                )
+              ],
+            ),
     );
   }
 }

--- a/lib/views/dev_settings_view.dart
+++ b/lib/views/dev_settings_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/services/save_and_load_shared_preferences.dart';
 
 import '../class/class_alarm_manager.dart';
@@ -14,14 +15,14 @@ import '../widgets/dialogs/error_dialog.dart';
 import '../widgets/dialogs/system_information_dialog.dart';
 import 'log_file_viewer.dart';
 
-class DevSettings extends StatefulWidget {
+class DevSettings extends ConsumerStatefulWidget {
   const DevSettings({super.key});
 
   @override
-  State<DevSettings> createState() => _DevSettingsState();
+  ConsumerState<DevSettings> createState() => _DevSettingsState();
 }
 
-class _DevSettingsState extends State<DevSettings> {
+class _DevSettingsState extends ConsumerState<DevSettings> {
   final EdgeInsets _settingsTileListPadding = EdgeInsets.fromLTRB(25, 2, 25, 2);
   final TextEditingController maxSizeOfSubscriptionBoundingBox =
       TextEditingController();
@@ -118,7 +119,7 @@ class _DevSettingsState extends State<DevSettings> {
                   debugPrint(
                       "reset read and notification status for all warnings");
                   for (Place p in myPlaceList) {
-                    p.resetReadAndNotificationStatusForAllWarnings(context);
+                    p.resetReadAndNotificationStatusForAllWarnings(ref);
                   }
                   final snackBar = SnackBar(
                     content: Text(

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:foss_warn/class/abstract_place.dart';
+import 'package:foss_warn/class/class_notification_service.dart';
+import 'package:foss_warn/class/class_unified_push_handler.dart';
+import 'package:foss_warn/main.dart';
+import 'package:foss_warn/services/geocode_handler.dart';
+import 'package:foss_warn/services/legacy_handler.dart';
+import 'package:foss_warn/services/list_handler.dart';
+import 'package:foss_warn/services/save_and_load_shared_preferences.dart';
+import 'package:foss_warn/services/update_provider.dart';
+import 'package:foss_warn/views/about_view.dart';
+import 'package:foss_warn/views/all_warnings_view.dart';
+import 'package:foss_warn/views/map_view.dart';
+import 'package:foss_warn/views/my_places_view.dart';
+import 'package:foss_warn/views/settings_view.dart';
+import 'package:foss_warn/widgets/dialogs/sort_by_dialog.dart';
+import 'package:unifiedpush/unifiedpush.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class HomeView extends ConsumerStatefulWidget {
+  const HomeView({super.key});
+
+  @override
+  ConsumerState<HomeView> createState() => _HomeViewState();
+}
+
+class _HomeViewState extends ConsumerState<HomeView> {
+  int _selectedIndex = userPreferences.startScreen; // selected start view
+
+  // list of views for the navigation bar
+  final List<Widget> _pages = <Widget>[
+    AllWarningsView(),
+    MyPlaces(),
+    MapView()
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+
+    // init unified push
+    UnifiedPush.initialize(
+      onNewEndpoint: UnifiedPushHandler
+          .onNewEndpoint, // takes (String endpoint, String instance) in args
+      onRegistrationFailed:
+          UnifiedPushHandler.onRegistrationFailed, // takes (String instance)
+      onUnregistered:
+          UnifiedPushHandler.onUnregistered, // takes (String instance)
+      onMessage: UnifiedPushHandler
+          .onMessage, // takes (Uint8List message, String instance) in args
+    );
+
+    loadMyPlacesList();
+    listenNotifications();
+    if (geocodeMap.isEmpty) {
+      debugPrint("call geocode handler");
+      geocodeHandler();
+    }
+
+    //display information if the app had to be resetted
+    showMigrationDialog(context);
+  }
+
+  void listenNotifications() {
+    NotificationService.onNotification.stream.listen(onClickedNotification);
+  }
+
+  void onClickedNotification(String? payload) {
+    //change view to "MyPlaces"
+    setState(() {
+      _selectedIndex = 1;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var updater = ref.read(updaterProvider);
+
+    return Scaffold(
+        // set to false to prevent the widget from jumping after closing the keyboard
+        resizeToAvoidBottomInset: false,
+        appBar: AppBar(
+          title: Text("FOSS Warn"),
+          actions: [
+            IconButton(
+              icon: Icon(Icons.sort),
+              tooltip: AppLocalizations.of(context)!
+                  .main_app_bar_action_sort_tooltip,
+              onPressed: () {
+                showDialog(
+                  context: context,
+                  builder: (BuildContext context) => SortByDialog(),
+                );
+                updater.updateReadStatusInList();
+              },
+            ),
+            IconButton(
+              onPressed: () {
+                for (Place p in myPlaceList) {
+                  p.markAllWarningsAsRead(ref);
+                }
+                final snackBar = SnackBar(
+                  content: Text(
+                    AppLocalizations.of(context)!
+                        .main_app_bar_tooltip_mark_all_warnings_as_read,
+                  ),
+                );
+
+                // Find the ScaffoldMessenger in the widget tree
+                // and use it to show a SnackBar.
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+              },
+              icon: Icon(Icons.mark_chat_read),
+              tooltip: AppLocalizations.of(context)!
+                  .main_app_bar_tooltip_mark_all_warnings_as_read,
+            ),
+            PopupMenuButton(
+                icon: Icon(Icons.more_vert),
+                onSelected: (result) {
+                  switch (result) {
+                    case 0:
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => Settings()),
+                      );
+                      break;
+                    case 1:
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => AboutView()),
+                      );
+                      break;
+                  }
+                },
+                itemBuilder: (context) => <PopupMenuEntry>[
+                      PopupMenuItem(
+                          value: 0,
+                          child: Text(AppLocalizations.of(context)!
+                              .main_dot_menu_settings)),
+                      PopupMenuItem(
+                          value: 1,
+                          child: Text(AppLocalizations.of(context)!
+                              .main_dot_menu_about))
+                    ])
+          ],
+        ),
+        bottomNavigationBar: NavigationBar(
+          destinations: <NavigationDestination>[
+            NavigationDestination(
+                icon: Icon(Icons.warning),
+                label: AppLocalizations.of(context)!.main_nav_bar_all_warnings),
+            NavigationDestination(
+                icon: Icon(Icons.place),
+                label: AppLocalizations.of(context)!.main_nav_bar_my_places),
+            NavigationDestination(icon: Icon(Icons.map), label: "Map")
+          ],
+          onDestinationSelected: (int index) {
+            setState(() {
+              _selectedIndex = index;
+            });
+          },
+          selectedIndex: _selectedIndex,
+        ),
+        body: _pages.elementAt(_selectedIndex));
+  }
+}

--- a/lib/views/my_place_detail_view.dart
+++ b/lib/views/my_place_detail_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_warn_message.dart';
 
 import '../class/abstract_place.dart';
@@ -8,13 +9,13 @@ import '../services/sort_warnings.dart';
 import '../widgets/warning_widget.dart';
 
 //@todo rename to MyPlacesDetailView
-class MyPlaceDetailScreen extends StatelessWidget {
+class MyPlaceDetailScreen extends ConsumerWidget {
   final Place _myPlace;
   const MyPlaceDetailScreen({super.key, required Place myPlace})
       : _myPlace = myPlace;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     sortWarnings(_myPlace.warnings); //@todo check if this works?
 
     /// generate a threaded list of alerts with updates of alert as thread
@@ -87,11 +88,11 @@ class MyPlaceDetailScreen extends StatelessWidget {
         actions: [
           IconButton(
             onPressed: () {
-              _myPlace.markAllWarningsAsRead(context);
+              _myPlace.markAllWarningsAsRead(ref);
               //@todo just a quick fix for the read state problem. We have to rethink our memory management
               myPlaceList
                   .firstWhere((e) => e.name == _myPlace.name)
-                  .markAllWarningsAsRead(context);
+                  .markAllWarningsAsRead(ref);
               final snackBar = SnackBar(
                 content: Text(
                   AppLocalizations.of(context)!

--- a/lib/views/my_places_view.dart
+++ b/lib/views/my_places_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/services/api_handler.dart';
-import 'package:provider/provider.dart';
 
 import '../widgets/my_place_widget.dart';
 import '../services/update_provider.dart';
@@ -9,14 +9,15 @@ import '../services/list_handler.dart';
 import '../widgets/connection_error_widget.dart';
 import 'add_my_place_with_map_view.dart';
 
-class MyPlaces extends StatefulWidget {
+class MyPlaces extends ConsumerStatefulWidget {
   const MyPlaces({super.key});
 
   @override
-  State<MyPlaces> createState() => _MyPlacesState();
+  ConsumerState<MyPlaces> createState() => _MyPlacesState();
 }
 
-class _MyPlacesState extends State<MyPlaces> with WidgetsBindingObserver {
+class _MyPlacesState extends ConsumerState<MyPlaces>
+    with WidgetsBindingObserver {
   bool _loading = false;
 
   @override
@@ -62,6 +63,8 @@ class _MyPlacesState extends State<MyPlaces> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    ref.watch(updaterProvider); // Just to rebuild on updates
+
     if (_loading == true) {
       load();
     }
@@ -78,73 +81,71 @@ class _MyPlacesState extends State<MyPlaces> with WidgetsBindingObserver {
       );
     }
 
-    return Consumer<Update>(
-      builder: (context, counter, child) => RefreshIndicator(
-        color: Theme.of(context).colorScheme.primary,
-        onRefresh: reloadData,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            //check if myPlaceList is empty, if not show list else show text
-            myPlaceList.isNotEmpty
-                ? SingleChildScrollView(
-                    physics: AlwaysScrollableScrollPhysics(),
-                    child: Padding(
-                        padding: const EdgeInsets.only(bottom: 65),
-                        child: Column(children: [
-                          ConnectionError(),
-                          ...myPlaceList
-                              .map((place) => MyPlaceWidget(myPlace: place)),
-                        ])),
-                  )
-                : Column(
-                    children: [
-                      ConnectionError(),
-                      Expanded(
-                        child: Center(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              Text(
-                                AppLocalizations.of(context)!
-                                    .my_place_no_place_added,
-                                style: TextStyle(
-                                    fontSize: 18, fontWeight: FontWeight.bold),
-                              ),
-                              SizedBox(
-                                height: 10,
-                              ),
-                              Text(
-                                AppLocalizations.of(context)!
-                                    .my_place_no_place_added_text,
-                                textAlign: TextAlign.center,
-                              ),
-                            ],
-                          ),
+    return RefreshIndicator(
+      color: Theme.of(context).colorScheme.primary,
+      onRefresh: reloadData,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          //check if myPlaceList is empty, if not show list else show text
+          myPlaceList.isNotEmpty
+              ? SingleChildScrollView(
+                  physics: AlwaysScrollableScrollPhysics(),
+                  child: Padding(
+                      padding: const EdgeInsets.only(bottom: 65),
+                      child: Column(children: [
+                        ConnectionError(),
+                        ...myPlaceList
+                            .map((place) => MyPlaceWidget(myPlace: place)),
+                      ])),
+                )
+              : Column(
+                  children: [
+                    ConnectionError(),
+                    Expanded(
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Text(
+                              AppLocalizations.of(context)!
+                                  .my_place_no_place_added,
+                              style: TextStyle(
+                                  fontSize: 18, fontWeight: FontWeight.bold),
+                            ),
+                            SizedBox(
+                              height: 10,
+                            ),
+                            Text(
+                              AppLocalizations.of(context)!
+                                  .my_place_no_place_added_text,
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
                         ),
                       ),
-                    ],
-                  ),
-            Positioned(
-              bottom: 10,
-              right: 10,
-              child: FloatingActionButton(
-                tooltip: AppLocalizations.of(context)!
-                    .my_places_view_add_new_place_button_tooltip,
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) =>
-                            AddMyPlaceWithMapView()), //AddMyPlaceView
-                  );
-                },
-                child: Icon(Icons.add),
-              ),
+                    ),
+                  ],
+                ),
+          Positioned(
+            bottom: 10,
+            right: 10,
+            child: FloatingActionButton(
+              tooltip: AppLocalizations.of(context)!
+                  .my_places_view_add_new_place_button_tooltip,
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) =>
+                          AddMyPlaceWithMapView()), //AddMyPlaceView
+                );
+              },
+              child: Icon(Icons.add),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/dialogs/choose_theme_dialog.dart
+++ b/lib/widgets/dialogs/choose_theme_dialog.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/main.dart';
 import 'package:foss_warn/services/save_and_load_shared_preferences.dart';
-import 'package:provider/provider.dart';
 
 import '../../services/update_provider.dart';
 
-class ChooseThemeDialog extends StatefulWidget {
+class ChooseThemeDialog extends ConsumerStatefulWidget {
   const ChooseThemeDialog({super.key});
 
   @override
-  State<ChooseThemeDialog> createState() => _ChooseThemeDialogState();
+  ConsumerState<ChooseThemeDialog> createState() => _ChooseThemeDialogState();
 }
 
-class _ChooseThemeDialogState extends State<ChooseThemeDialog> {
+class _ChooseThemeDialogState extends ConsumerState<ChooseThemeDialog> {
   List<Widget> generateBrightnessButtons() {
     List<ThemeMode> themeModes = [
       ThemeMode.light,
@@ -28,6 +28,8 @@ class _ChooseThemeDialogState extends State<ChooseThemeDialog> {
   }
 
   Widget generateBrightnessButton(ThemeMode themeMode) {
+    var updater = ref.read(updaterProvider);
+
     return TextButton(
       style: TextButton.styleFrom(
           padding: EdgeInsets.only(left: 10, right: 10),
@@ -45,7 +47,6 @@ class _ChooseThemeDialogState extends State<ChooseThemeDialog> {
           userPreferences.selectedThemeMode = themeMode;
         });
         // Reload the full app for theme changes to reflect
-        final updater = Provider.of<Update>(context, listen: false);
         updater.updateView();
         saveSettings();
       },
@@ -115,6 +116,8 @@ class _ChooseThemeDialogState extends State<ChooseThemeDialog> {
   }
 
   Widget generateColorButton(ThemeData theme) {
+    var updater = ref.read(updaterProvider);
+
     return Container(
       width: 90,
       padding: EdgeInsets.all(1),
@@ -131,7 +134,6 @@ class _ChooseThemeDialogState extends State<ChooseThemeDialog> {
             }
           });
           // Reload the full app for theme changes to reflect
-          final updater = Provider.of<Update>(context, listen: false);
           updater.updateView();
           saveSettings();
         },

--- a/lib/widgets/dialogs/delete_place_dialog.dart
+++ b/lib/widgets/dialogs/delete_place_dialog.dart
@@ -1,22 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_fpas_place.dart';
 import 'package:foss_warn/class/class_unified_push_handler.dart';
 import '../../class/abstract_place.dart';
 import '../../services/update_provider.dart';
-import 'package:provider/provider.dart';
 
-class DeletePlaceDialog extends StatefulWidget {
+class DeletePlaceDialog extends ConsumerStatefulWidget {
   final Place myPlace;
   const DeletePlaceDialog({super.key, required this.myPlace});
 
   @override
-  State<DeletePlaceDialog> createState() => _DeletePlaceDialogState();
+  ConsumerState<DeletePlaceDialog> createState() => _DeletePlaceDialogState();
 }
 
-class _DeletePlaceDialogState extends State<DeletePlaceDialog> {
+class _DeletePlaceDialogState extends ConsumerState<DeletePlaceDialog> {
   @override
   Widget build(BuildContext context) {
+    var updater = ref.read(updaterProvider);
+
     return AlertDialog(
       title: Text(AppLocalizations.of(context)!.delete_place_headline),
       content: Column(
@@ -47,7 +49,6 @@ class _DeletePlaceDialogState extends State<DeletePlaceDialog> {
                   (widget.myPlace as FPASPlace).subscriptionId);
             }
 
-            final updater = Provider.of<Update>(context, listen: false);
             updater.deletePlace(widget.myPlace);
             Navigator.of(context).pop();
           },

--- a/lib/widgets/dialogs/error_dialog.dart
+++ b/lib/widgets/dialogs/error_dialog.dart
@@ -1,24 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/main.dart';
-import 'package:provider/provider.dart';
 
 import '../../services/update_provider.dart';
 
-class ErrorDialog extends StatefulWidget {
+class ErrorDialog extends ConsumerStatefulWidget {
   const ErrorDialog({super.key});
 
   @override
-  State<ErrorDialog> createState() => _ErrorDialogState();
+  ConsumerState<ErrorDialog> createState() => _ErrorDialogState();
 }
 
-class _ErrorDialogState extends State<ErrorDialog> {
+class _ErrorDialogState extends ConsumerState<ErrorDialog> {
   // used to scroll horizontal and vertical at the same time
   final ScrollController _horizontal = ScrollController(),
       _vertical = ScrollController();
   @override
   Widget build(BuildContext context) {
+    var updater = ref.read(updaterProvider);
+
     return FutureBuilder<String>(
       future: ErrorLogger.readLog(),
       builder: (context, snapshot) {
@@ -104,7 +106,6 @@ class _ErrorDialogState extends State<ErrorDialog> {
                 ),
                 TextButton(
                   onPressed: () {
-                    final updater = Provider.of<Update>(context, listen: false);
                     updater.updateView();
                     Navigator.of(context).pop();
                   },

--- a/lib/widgets/map_widget.dart
+++ b/lib/widgets/map_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:foss_warn/main.dart';
 
 import '../class/abstract_place.dart';
 import '../class/class_area.dart';
 import '../class/class_warn_message.dart';
-import '../main.dart';
 import '../services/list_handler.dart';
 
 class MapWidget extends StatefulWidget {

--- a/lib/widgets/warning_widget.dart
+++ b/lib/widgets/warning_widget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/services/list_handler.dart';
-import 'package:provider/provider.dart';
 
 import '../class/abstract_place.dart';
 import '../class/class_warn_message.dart';
@@ -16,7 +16,7 @@ import '../services/translate_and_colorize_warning.dart';
 import 'dialogs/message_type_explanation.dart';
 import 'dialogs/category_explanation.dart';
 
-class WarningWidget extends StatelessWidget {
+class WarningWidget extends ConsumerWidget {
   final Place? _place;
   final List<WarnMessage>? _updateThread;
   final WarnMessage _warnMessage;
@@ -33,11 +33,12 @@ class WarningWidget extends StatelessWidget {
         _isMyPlaceWarning = isMyPlaceWarning;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    var updater = ref.watch(updaterProvider);
+
     List<String> areaList = []; //@todo rename
 
     updatePrevView() {
-      final updater = Provider.of<Update>(context, listen: false);
       updater.updateReadStatusInList();
     }
 
@@ -56,186 +57,178 @@ class WarningWidget extends StatelessWidget {
 
     areaList = generateAreaList();
 
-    return Consumer<Update>(
-      builder: (context, counter, child) => Card(
-        child: InkWell(
-          onTap: () {
-            try {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) => DetailScreen(
-                          warnMessage: _warnMessage,
-                          place: _place,
-                        )),
-              ).then((value) => updatePrevView());
-            } catch (e) {
-              ErrorLogger.writeErrorLog(
-                  "WarningWidget.dart",
-                  "Error of Type: ${e.runtimeType} while displaying alert: ${_warnMessage.identifier}",
-                  e.toString());
-              appState.error = true;
-            }
-          },
-          child: Padding(
-            padding: EdgeInsets.all(12),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                _buildReadStateButton(context),
-                SizedBox(
-                  width: 5,
-                ),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Container(
-                            color: Colors.indigo,
-                            padding: EdgeInsets.all(5),
-                            child: InkWell(
-                              onTap: () {
-                                showDialog(
-                                  context: context,
-                                  builder: (BuildContext context) {
-                                    return CategoryExplanation();
-                                  },
-                                );
-                              },
-                              child: Text(
-                                translateWarningCategory(
-                                    _warnMessage.info[0].category.isNotEmpty
-                                        ? _warnMessage.info[0].category[0].name
-                                        : "",
-                                    context), //@todo display more then one category if available
-                                style: Theme.of(context).textTheme.displaySmall,
-                              ),
-                            ),
-                          ),
-                          SizedBox(
-                            width: 10,
-                          ),
-                          Container(
-                            color: chooseWarningTypeColor(
-                                _warnMessage.messageType.name),
-                            padding: EdgeInsets.all(5),
-                            child: InkWell(
-                              onTap: () {
-                                showDialog(
-                                  context: context,
-                                  builder: (BuildContext context) {
-                                    return MessageTypeExplanation();
-                                  },
-                                );
-                              },
-                              child: Text(
-                                translateWarningType(
-                                    _warnMessage.messageType.name, context),
-                                style: TextStyle(
-                                    fontSize: 12, color: Colors.white),
-                              ),
-                            ),
-                          ),
-                          SizedBox(
-                            width: 10,
-                          ),
-                          Expanded(
-                            child: SizedBox(
-                              width: 100,
-                              child: Text(
-                                areaList.length > 1
-                                    ? "${areaList.first} ${AppLocalizations.of(context)!.warning_widget_and} ${areaList.length - 1} ${AppLocalizations.of(context)!.warning_widget_other}"
-                                    : areaList.isNotEmpty
-                                        ? areaList.first
-                                        : AppLocalizations.of(context)!
-                                            .warning_widget_unknown,
-                                style: TextStyle(fontSize: 12),
-                              ),
-                            ),
-                          )
-                        ],
-                      ),
-                      SizedBox(
-                        height: 5,
-                      ),
-                      Text(
-                        _warnMessage.info[0].headline,
-                        style: TextStyle(
-                            fontSize: 18, fontWeight: FontWeight.bold),
-                      ),
-                      SizedBox(
-                        height: 5,
-                      ),
-                      SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: Row(
-                          children: [
-                            Text(
-                              formatSentDate(_warnMessage.sent),
-                              style: TextStyle(fontSize: 12),
-                            ),
-                            SizedBox(
-                              width: 20,
-                            ),
-                            Text(
-                              _warnMessage.source.name.toUpperCase(),
-                              style: TextStyle(fontSize: 12),
-                            ),
-                          ],
-                        ),
-                      )
-                    ],
-                  ),
-                ),
-                Column(
+    return Card(
+      child: InkWell(
+        onTap: () {
+          try {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => DetailScreen(
+                        warnMessage: _warnMessage,
+                        place: _place,
+                      )),
+            ).then((value) => updatePrevView());
+          } catch (e) {
+            ErrorLogger.writeErrorLog(
+                "WarningWidget.dart",
+                "Error of Type: ${e.runtimeType} while displaying alert: ${_warnMessage.identifier}",
+                e.toString());
+            appState.error = true;
+          }
+        },
+        child: Padding(
+          padding: EdgeInsets.all(12),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _buildReadStateButton(ref),
+              SizedBox(width: 5),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    IconButton(
-                      onPressed: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => DetailScreen(
-                                    warnMessage: _warnMessage,
-                                    place: _place,
-                                  )),
-                        ).then((value) => updatePrevView());
-                      },
-                      icon: Icon(Icons.read_more),
-                    ),
-                    //_updateThread != null ? _updateThread!.length > 1 ? IconButton(onPressed: () {}, icon: Icon(Icons.account_tree)): SizedBox(): SizedBox(),
-                    (_updateThread != null && _updateThread.length > 1)
-                        ? IconButton(
-                            tooltip: AppLocalizations.of(context)!
-                                .warning_widget_update_thread_tooltip,
-                            onPressed: () {
-                              debugPrint("${_updateThread.length}");
-                              debugPrint("$_updateThread");
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => AlertUpdateThreadView(
-                                          latestAlert: _updateThread[0],
-                                          previousNowUpdatedAlerts:
-                                              _updateThread.sublist(
-                                                  1, _updateThread.length),
-                                        )),
+                    Row(
+                      children: [
+                        Container(
+                          color: Colors.indigo,
+                          padding: EdgeInsets.all(5),
+                          child: InkWell(
+                            onTap: () {
+                              showDialog(
+                                context: context,
+                                builder: (BuildContext context) {
+                                  return CategoryExplanation();
+                                },
                               );
                             },
-                            icon: Icon(Icons.account_tree))
-                        : SizedBox(),
+                            child: Text(
+                              translateWarningCategory(
+                                  _warnMessage.info[0].category.isNotEmpty
+                                      ? _warnMessage.info[0].category[0].name
+                                      : "",
+                                  context), //@todo display more then one category if available
+                              style: Theme.of(context).textTheme.displaySmall,
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          width: 10,
+                        ),
+                        Container(
+                          color: chooseWarningTypeColor(
+                              _warnMessage.messageType.name),
+                          padding: EdgeInsets.all(5),
+                          child: InkWell(
+                            onTap: () {
+                              showDialog(
+                                context: context,
+                                builder: (BuildContext context) {
+                                  return MessageTypeExplanation();
+                                },
+                              );
+                            },
+                            child: Text(
+                              translateWarningType(
+                                  _warnMessage.messageType.name, context),
+                              style:
+                                  TextStyle(fontSize: 12, color: Colors.white),
+                            ),
+                          ),
+                        ),
+                        SizedBox(
+                          width: 10,
+                        ),
+                        Expanded(
+                          child: SizedBox(
+                            width: 100,
+                            child: Text(
+                              areaList.length > 1
+                                  ? "${areaList.first} ${AppLocalizations.of(context)!.warning_widget_and} ${areaList.length - 1} ${AppLocalizations.of(context)!.warning_widget_other}"
+                                  : areaList.isNotEmpty
+                                      ? areaList.first
+                                      : AppLocalizations.of(context)!
+                                          .warning_widget_unknown,
+                              style: TextStyle(fontSize: 12),
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
+                    SizedBox(height: 5),
+                    Text(
+                      _warnMessage.info[0].headline,
+                      style:
+                          TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                    SizedBox(height: 5),
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Row(
+                        children: [
+                          Text(
+                            formatSentDate(_warnMessage.sent),
+                            style: TextStyle(fontSize: 12),
+                          ),
+                          SizedBox(
+                            width: 20,
+                          ),
+                          Text(
+                            _warnMessage.source.name.toUpperCase(),
+                            style: TextStyle(fontSize: 12),
+                          ),
+                        ],
+                      ),
+                    )
                   ],
                 ),
-              ],
-            ),
+              ),
+              Column(
+                children: [
+                  IconButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => DetailScreen(
+                                  warnMessage: _warnMessage,
+                                  place: _place,
+                                )),
+                      ).then((value) => updatePrevView());
+                    },
+                    icon: Icon(Icons.read_more),
+                  ),
+                  (_updateThread != null && _updateThread.length > 1)
+                      ? IconButton(
+                          tooltip: AppLocalizations.of(context)!
+                              .warning_widget_update_thread_tooltip,
+                          onPressed: () {
+                            debugPrint("${_updateThread.length}");
+                            debugPrint("$_updateThread");
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) => AlertUpdateThreadView(
+                                        latestAlert: _updateThread[0],
+                                        previousNowUpdatedAlerts: _updateThread
+                                            .sublist(1, _updateThread.length),
+                                      )),
+                            );
+                          },
+                          icon: Icon(Icons.account_tree))
+                      : SizedBox(),
+                ],
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  Widget _buildReadStateButton(BuildContext context) {
+  Widget _buildReadStateButton(WidgetRef ref) {
+    var updater = ref.read(updaterProvider);
+
     // do not show a clickable red/green button for non-my-place warnings
     // if _isMyPlaceWarning = true
     // the read state of these warning is not saved anyways
@@ -262,7 +255,6 @@ class WarningWidget extends StatelessWidget {
               .firstWhere((e) => e.identifier == _warnMessage.identifier)
               .read = _warnMessage.read;
         }
-        final updater = Provider.of<Update>(context, listen: false);
         updater.updateReadStatusInList();
         // save places list to store new read state
         await saveMyPlacesList();

--- a/lib/widgets/warning_widget.dart
+++ b/lib/widgets/warning_widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/services/list_handler.dart';
+import 'package:foss_warn/services/warning.dart';
 
 import '../class/abstract_place.dart';
 import '../class/class_warn_message.dart';
@@ -59,16 +60,18 @@ class WarningWidget extends ConsumerWidget {
 
     return Card(
       child: InkWell(
-        onTap: () {
+        onTap: () async {
+          ref.read(currentWarningProvider.notifier).state = ActiveWarning(
+            message: _warnMessage,
+            place: _place,
+          );
           try {
-            Navigator.push(
+            await Navigator.push(
               context,
-              MaterialPageRoute(
-                  builder: (context) => DetailScreen(
-                        warnMessage: _warnMessage,
-                        place: _place,
-                      )),
-            ).then((value) => updatePrevView());
+              MaterialPageRoute(builder: (context) => DetailScreen()),
+            );
+
+            updatePrevView();
           } catch (e) {
             ErrorLogger.writeErrorLog(
                 "WarningWidget.dart",
@@ -186,15 +189,20 @@ class WarningWidget extends ConsumerWidget {
               Column(
                 children: [
                   IconButton(
-                    onPressed: () {
-                      Navigator.push(
+                    onPressed: () async {
+                      var activeWarning = ActiveWarning(
+                        message: _warnMessage,
+                        place: _place,
+                      );
+                      ref.read(currentWarningProvider.notifier).state =
+                          activeWarning;
+
+                      await Navigator.push(
                         context,
-                        MaterialPageRoute(
-                            builder: (context) => DetailScreen(
-                                  warnMessage: _warnMessage,
-                                  place: _place,
-                                )),
-                      ).then((value) => updatePrevView());
+                        MaterialPageRoute(builder: (context) => DetailScreen()),
+                      );
+
+                      updatePrevView();
                     },
                     icon: Icon(Icons.read_more),
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -187,6 +187,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -317,14 +325,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -429,14 +429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  provider:
-    dependency: "direct main"
+  riverpod:
+    dependency: transitive
     description:
-      name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "2.6.1"
   rxdart:
     dependency: "direct main"
     description:
@@ -546,6 +546,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   flutter_local_notifications: ^17.2.4
   shared_preferences: ^2.3.3
   shared_preferences_android: ^2.4.0
-  provider: ^6.1.1
   rxdart: ^0.28.0
   url_launcher: ^6.3.1
   share_plus: ^10.1.1
@@ -34,6 +33,7 @@ dependencies:
 
   path_provider: any
   vector_tile_renderer: any
+  flutter_riverpod: ^2.6.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/warning_detail_view_contact_field_test.dart
+++ b/test/warning_detail_view_contact_field_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:foss_warn/class/class_area.dart';
 import 'package:foss_warn/class/class_info.dart';
@@ -12,6 +13,7 @@ import 'package:foss_warn/enums/category.dart' as cap_category;
 import 'package:foss_warn/enums/status.dart';
 import 'package:foss_warn/enums/urgency.dart';
 import 'package:foss_warn/enums/warning_source.dart';
+import 'package:foss_warn/services/warning.dart';
 import 'package:foss_warn/views/warning_detail_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -98,8 +100,20 @@ Widget makeTestableWidget({required Widget myWidget}) {
 void testWidget(String testCaseName, String contactFieldText,
     String contactFieldExpectedText) {
   WarnMessage wm = createDummyWarnMessage(contactFieldText);
-  Widget testWidget =
-      makeTestableWidget(myWidget: DetailScreen(warnMessage: wm));
+  Widget testWidget = makeTestableWidget(
+    myWidget: ProviderScope(
+      overrides: [
+        currentWarningProvider.overrideWith(
+          (ref) => ActiveWarning(message: wm, place: null),
+        ),
+      ],
+      child: Consumer(
+        builder: (context, ref, child) {
+          return DetailScreen();
+        },
+      ),
+    ),
+  );
 
   testWidgets(testCaseName, (tester) async {
     await tester.pumpWidget(testWidget);


### PR DESCRIPTION
Depends on #162 for it's usage of Riverpod.

This is required to make routing easier when using Navigator 3 which I'd like to move the app to soon (using `go_router`). Using that only simple arguments can be easily provided too screens as it's largely URL-based, so int's, strings, booleans, rather than complex objects.