### PR TITLE
feat: add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,8 @@
+repos:
+- repo: https://github.com/dluksza/flutter-analyze-pre-commit
+  rev: 4afcaa82fc368d40d486256bf4edba329bf667bb
+  hooks:
+  - id: dart-format
+    args: [lib/*]
+  - id: flutter-analyze
+    args: [lib/*]


### PR DESCRIPTION
Using the pre-commit tool[1] this configuration will make sure no code that doesn't pass the formatter or linter is committed. This will prevent commits like "run the formatter" and "fix linting errors" because they won't have been committed in the first place.

You can enable the pre-commit hook locally using "pre-commit install", make sure you have installed the "pre-commit" tool from your distribution repositories first.

[1] https://pre-commit.com/