### PR TITLE
add webpush support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           channel: 'stable'
           cache: true
           cache-key: "${{ runner.OS }}-flutter-install-cache"
-          flutter-version: "3.24.5"
+          flutter-version: "3.29.0"
 
       - run: flutter pub get
       - run: flutter gen-l10n
@@ -46,7 +46,7 @@ jobs:
           channel: 'stable'
           cache: true
           cache-key: "${{ runner.OS }}-flutter-install-cache"
-          flutter-version: "3.24.5"
+          flutter-version: "3.29.0"
 
       - run: flutter pub get
       - run: flutter gen-l10n

--- a/lib/class/class_area.dart
+++ b/lib/class/class_area.dart
@@ -24,7 +24,8 @@ class Area {
 
   Area.fromJson(Map<String, dynamic> json)
       : description = json['areaDesc'],
-        geoJson = json['geoJson'] ?? "";
+        geoJson = json['geoJson'] ??
+            ""; //@TODO(Nucleus) geoJson should never be "" as this produces an error if we try to use the geoJson for the map
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         'areaDesc': description,
@@ -59,6 +60,16 @@ class Area {
       }
     }
     return result;
+  }
+
+  /// create an area from the CAP data
+  /// convert he CAP geo info into geo json data
+  static Area areaFromJsonWithCAPData(
+    Map<String, dynamic> data,
+  ) {
+    Map<String, dynamic> capToGeoJson = _convertCAPGeoInfoToGeoJson(data);
+    data.putIfAbsent("geoJson", () => jsonEncode(capToGeoJson));
+    return Area.fromJson(data);
   }
 
   /// converts tha CAP geo information to geo json

--- a/lib/class/class_area.dart
+++ b/lib/class/class_area.dart
@@ -218,7 +218,7 @@ class Area {
     List<String> debugResult = [];
     try {
       GeoJsonParser myGeoJson = GeoJsonParser(
-        defaultPolygonFillColor: const Color(0xFFB01917).withValues(alpha: .2),
+        defaultPolygonFillColor: const Color(0xFFB01917).withValues(alpha: 0.2),
         defaultPolygonBorderColor: const Color(0xFFFB8C00),
         defaultPolylineStroke: 1,
       );

--- a/lib/class/class_area.dart
+++ b/lib/class/class_area.dart
@@ -218,7 +218,7 @@ class Area {
     List<String> debugResult = [];
     try {
       GeoJsonParser myGeoJson = GeoJsonParser(
-        defaultPolygonFillColor: const Color(0xFFB01917).withOpacity(0.2),
+        defaultPolygonFillColor: const Color(0xFFB01917).withValues(alpha: .2),
         defaultPolygonBorderColor: const Color(0xFFFB8C00),
         defaultPolylineStroke: 1,
       );

--- a/lib/class/class_bounding_box.dart
+++ b/lib/class/class_bounding_box.dart
@@ -15,7 +15,7 @@ class BoundingBox {
   factory BoundingBox.fromJson(Map<String, dynamic> json) {
     var minLatLng = (json['min_latLng'] as Map<String, dynamic>)
         .map((key, value) => MapEntry(key, value as List<dynamic>));
-    var maxLatLng = (json['min_latLng'] as Map<String, dynamic>)
+    var maxLatLng = (json['max_latLng'] as Map<String, dynamic>)
         .map((key, value) => MapEntry(key, value as List<dynamic>));
 
     /// create new warnMessage objects from saved data

--- a/lib/class/class_info.dart
+++ b/lib/class/class_info.dart
@@ -107,7 +107,7 @@ class Info {
             .toList(),
       );
     } else {
-      areas = [Area.fromJson(json['area'])];
+      areas = [Area.areaFromJsonWithCAPData(json['area'])];
     }
 
     return Info(

--- a/lib/class/class_unified_push_handler.dart
+++ b/lib/class/class_unified_push_handler.dart
@@ -94,7 +94,7 @@ class UnifiedPushHandler {
   }
 
   /// register for push notifications and keep registration up to date
-  /// This methode needs to called at every app startup
+  /// This method needs to called at every app startup
   static Future<void> setupUnifiedPush(
     BuildContext context,
     WidgetRef ref,
@@ -134,10 +134,9 @@ class UnifiedPushHandler {
       );
     } else {
       // Get a list of distributors that are available
-      List<String> distributors = await UnifiedPush.getDistributors([
-        //featureAndroidBytesMessage,
-      ] // Optionnal String Array with required features
-          );
+      List<String> distributors = await UnifiedPush.getDistributors(
+        [], // Optional String Array with required features
+      );
 
       if (distributors.isEmpty) {
         // there is no distributor installed. Inform user about it

--- a/lib/class/class_unified_push_handler.dart
+++ b/lib/class/class_unified_push_handler.dart
@@ -1,36 +1,40 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/services/api_handler.dart';
 import 'package:foss_warn/class/class_fpas_place.dart';
 import 'package:foss_warn/services/list_handler.dart';
 import 'package:foss_warn/services/warnings.dart';
 
-import 'package:unifiedpush/constants.dart';
 import 'package:unifiedpush/unifiedpush.dart';
+import '../services/alert_api/fpas.dart';
 import '../services/check_for_my_places_warnings.dart';
 import 'package:foss_warn/main.dart';
 import '../widgets/dialogs/no_up_distributor_found_dialog.dart';
 import '../widgets/dialogs/select_unified_push_distributor_dialog.dart';
 
 class UnifiedPushHandler {
-  static void onNewEndpoint(String endpoint, String instance) {
-    debugPrint("new Entpoint:$endpoint");
+  static void onNewEndpoint(PushEndpoint endpoint, String instance) {
+    debugPrint("new Endpoint:${endpoint.url}");
     if (instance != userPreferences.unifiedPushInstance) {
       return;
     }
     userPreferences.unifiedPushRegistered = true;
-    userPreferences.unifiedPushEndpoint = endpoint;
+    userPreferences.unifiedPushEndpoint = endpoint.url;
+    if (endpoint.pubKeySet != null) {
+      userPreferences.webPushPublicKey = endpoint.pubKeySet!.pubKey;
+      userPreferences.webPushAuthKey = endpoint.pubKeySet!.auth;
+    }
   }
 
-  static void onRegistrationFailed(String instance) {
+  static void onRegistrationFailed(FailedReason failedReason, instance) {
     // @todo error handling
     ErrorLogger.writeErrorLog(
       "class_unifiedPushHandler",
       "UnifiedPush registration failed",
-      "",
+      failedReason.name,
     );
     debugPrint("Registration failed");
   }
@@ -54,8 +58,8 @@ class UnifiedPushHandler {
   static Future<void> onMessage({
     required AlertAPI alertApi,
     required MyPlacesService myPlacesService,
+    required PushMessage message,
     required WarningService warningService,
-    required Uint8List message,
     required String instance,
     required List<Place> myPlaces,
   }) async {
@@ -64,7 +68,17 @@ class UnifiedPushHandler {
       return;
     }
     debugPrint("onNotification");
-    var payload = utf8.decode(message);
+    // check if the message is successfully decrypted and add log error if not
+    // if the message is not successfully decrypted check for myPlaceWarnings
+    // anyway
+    if (!message.decrypted) {
+      ErrorLogger.writeErrorLog(
+        "class_unified_push_handler.dart",
+        "error while handling onMessage",
+        "Message is not decrypted",
+      );
+    }
+    var payload = utf8.decode(message.content);
     debugPrint("message: $payload");
     if (payload.contains("[DEBUG]") || payload.contains("[HEARTBEAT]")) {
       // system message or debug
@@ -79,28 +93,49 @@ class UnifiedPushHandler {
     return;
   }
 
-  /// register for push notifications
-  static Future<void> setupUnifiedPush(BuildContext context) async {
-    debugPrint("setup distributor");
-    // Check if a distributor is already registered
-    if (await UnifiedPush.getDistributor() != "" &&
-        await UnifiedPush.getDistributor() != null &&
-        userPreferences.unifiedPushRegistered) {
-      // enpoint already setted up. Nothing to change
-      return;
-    } else if (await UnifiedPush.getDistributor() != null) {
-      // Re-register in case something broke
-      await UnifiedPush.registerApp(
-          userPreferences
-              .unifiedPushInstance, // Optional String, to get multiple endpoints (one per instance)
-          [
-            featureAndroidBytesMessage,
-          ] // Optional String Array with required features
-          );
+  /// register for push notifications and keep registration up to date
+  /// This methode needs to called at every app startup
+  static Future<void> setupUnifiedPush(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    // fetch fresh server config to check which push services are supported
+    AlertAPI alertAPI = ref.read(alertApiProvider);
+    ServerSettings serverSettings = await alertAPI.fetchServerSettings();
+    // check if webpush / encrypted UP is supported
+    bool isEncryptedUnifiedPushSupported =
+        serverSettings.supportedPushServices["UNIFIED_PUSH_ENCRYPTED"] ?? false;
+
+    // if server supports webpush, try to fetch the vapid key
+    if (userPreferences.webPushVapidKey == null &&
+        isEncryptedUnifiedPushSupported) {
+      try {
+        userPreferences.webPushVapidKey =
+            await alertAPI.fetchVapidKeyForWebPush();
+      } on VapidKeyException {
+        isEncryptedUnifiedPushSupported = false;
+        ErrorLogger.writeErrorLog(
+          "class_unified_push_handler.dart",
+          "setup unifiedPush",
+          "Failed to fetch VAPID key for webpush",
+        );
+      }
+    }
+
+    if (await UnifiedPush.getDistributor() != null) {
+      // already registered - just register again without changing anything
+      // register UnifiedPush with same distributor url and token as
+      // this is required by the unifiedPush plugin
+      await UnifiedPush.register(
+        userPreferences
+            .unifiedPushInstance, // Optional String, to get multiple endpoints (one per instance)
+        [], // Optional String Array with required features
+        userPreferences.webPushVapidKey,
+      );
     } else {
       // Get a list of distributors that are available
       List<String> distributors = await UnifiedPush.getDistributors([
-        featureAndroidBytesMessage,
+        //featureAndroidBytesMessage,
       ] // Optionnal String Array with required features
           );
 
@@ -123,13 +158,12 @@ class UnifiedPushHandler {
       // save the distributor
       await UnifiedPush.saveDistributor(picked ?? distributors.first);
       // register your app to the distributor
-      await UnifiedPush.registerApp(
-          userPreferences
-              .unifiedPushInstance, // optional String, to get multiple endpoints (one per instance)
-          [
-            featureAndroidBytesMessage,
-          ] // Optional String Array with required features
-          );
+      await UnifiedPush.register(
+        userPreferences
+            .unifiedPushInstance, // optional String, to get multiple endpoints (one per instance)
+        [], // Optional String Array with required features
+        userPreferences.webPushVapidKey,
+      );
     }
 
     debugPrint(

--- a/lib/class/class_user_preferences.dart
+++ b/lib/class/class_user_preferences.dart
@@ -352,7 +352,8 @@ class UserPreferences {
     _preferences.setBool("unifiedPushRegistered", value);
   }
 
-  final List<String> _fossPublicAlertSubscriptionIdsToSubscribe = [];
+  final List<String> _fossPublicAlertSubscriptionIdsToSubscribe =
+      []; //@TODO(nucleus): there is the "server" missing in the name
   List<String> get fossPublicAlertSubscriptionIdsToSubscribe {
     List<String>? data =
         _preferences.getStringList("fossPublicAlertSubscriptionIdsToSubscribe");
@@ -379,4 +380,43 @@ class UserPreferences {
   final String unifiedPushInstance = "FOSSWarn";
   final String osmTileServerULR =
       "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+
+  String? get webPushVapidKey {
+    String? data = _preferences.getString("webPushVapidKey");
+    return data;
+  }
+
+  set webPushVapidKey(String? value) {
+    if (value == null) {
+      _preferences.remove("webPushVapidKey");
+    } else {
+      _preferences.setString("webPushVapidKey", value);
+    }
+  }
+
+  String? get webPushAuthKey {
+    String? data = _preferences.getString("webPushAuthKey");
+    return data;
+  }
+
+  set webPushAuthKey(String? value) {
+    if (value == null) {
+      _preferences.remove("webPushAuthKey");
+    } else {
+      _preferences.setString("webPushAuthKey", value);
+    }
+  }
+
+  String? get webPushPublicKey {
+    String? data = _preferences.getString("webPushPublicKey");
+    return data;
+  }
+
+  set webPushPublicKey(String? value) {
+    if (value == null) {
+      _preferences.remove("webPushPublicKey");
+    } else {
+      _preferences.setString("webPushPublicKey", value);
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -391,6 +391,8 @@
   "@delete_place_delete": {},
   "delete_place_cancel": "Cancel",
   "@delete_place_cancel": {},
+  "delete_place_error": "Can not remove place. Please check your internet connection.",
+  "@delete_place_error": {},
   "explanation_warning_level_headline": "Warning levels",
   "@explanation_warning_level_headline": {},
   "explanation_warning_level_attention": "Attention",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -327,6 +327,8 @@
   "@welcome_view_end_button": {},
   "connection_error_no_internet": "No server connection",
   "@connection_error_no_internet": {},
+  "connection_error_app_error": "Ups Something went wrong. Please contact the developer",
+  "@connection_error_no_internet": {},
   "font_size_headline": "Font size",
   "@font_size_headline": {},
   "font_size_big": "Big",

--- a/lib/services/alert_api/fpas.dart
+++ b/lib/services/alert_api/fpas.dart
@@ -95,6 +95,16 @@ class FPASApi implements AlertAPI {
       },
     );
 
+    switch (response.statusCode) {
+      case 200: // nothing to do
+        break;
+      default:
+        throw UndefinedServerError(
+          message: response.body,
+          statusCode: response.statusCode,
+        );
+    }
+
     var xml2jsonTransformer = Xml2Json();
     xml2jsonTransformer.parse(utf8.decode(response.bodyBytes));
 

--- a/lib/services/api_handler.dart
+++ b/lib/services/api_handler.dart
@@ -110,8 +110,22 @@ class PlaceSubscriptionError implements Exception {}
 /// Thrown when the server indicates something went wrong while unregistering
 class UnregisterAreaError implements Exception {}
 
+// Thrown if the server response indicates that the subscription is invalid or deleted on serverside
+class InvalidSubscriptionError implements Exception {}
+
 /// Thrown when the server indicates something went wrong while registering
-class RegisterAreaError implements Exception {}
+class RegisterAreaError implements Exception {
+  final String message;
+  RegisterAreaError({required this.message});
+
+  @override
+  String toString() {
+    return "RegisterAreaError: $message";
+  }
+}
+
+/// Thrown when the server indicates something went wrong while fetching the vapid key
+class VapidKeyException implements Exception {}
 
 class ServerSettings {
   final String url;
@@ -120,6 +134,7 @@ class ServerSettings {
   final String privacyNotice;
   final String termsOfService;
   final int congestionState;
+  final Map<String, dynamic> supportedPushServices;
 
   ServerSettings({
     required this.url,
@@ -128,6 +143,7 @@ class ServerSettings {
     required this.privacyNotice,
     required this.termsOfService,
     required this.congestionState,
+    required this.supportedPushServices,
   });
 }
 
@@ -142,6 +158,13 @@ abstract class AlertAPI {
   /// Throws an exception if the url is not a valid FPAS server url or something
   /// else went wrong
   Future<ServerSettings> fetchServerSettings({String overrideUrl});
+
+  /// fetch the for webpush needed vapid key from the server
+  ///
+  /// returns the vapid key as String if it was successfully fetched
+  ///
+  /// Throws an exception if something went wrong
+  Future<String> fetchVapidKeyForWebPush();
 
   /// Get all alerts for a given place.
   /// Make sure you have registered to the area before you retrieve alerts for it.

--- a/lib/services/api_handler.dart
+++ b/lib/services/api_handler.dart
@@ -25,11 +25,11 @@ Future<void> callAPI({
 
   await loadMyPlacesList();
 
+  var updatedWarnings = <WarnMessage>[];
   for (Place place in places) {
     List<String> alertIds = [];
     try {
-      alertIds =
-      await alertApi.getAlerts(subscriptionId: place.subscriptionId);
+      alertIds = await alertApi.getAlerts(subscriptionId: place.subscriptionId);
     } on InvalidSubscriptionError {
       //@TODO(Nucleus) handle invalid subscription
       continue;
@@ -42,7 +42,7 @@ Future<void> callAPI({
       // inform user about error
       appState.error = true;
     }
-    var warnings = await Future.wait([
+    List<WarnMessage> warnings = await Future.wait([
       for (String alertId in alertIds) ...[
         alertApi.getAlertDetail(
           alertId: alertId,
@@ -51,8 +51,7 @@ Future<void> callAPI({
       ],
     ]);
 
-    var updatedWarnings = <WarnMessage>[];
-    for (var warning in warnings) {
+    for (WarnMessage warning in warnings) {
       updatedWarnings.add(
         warning.copyWith(
           isUpdateOfAlreadyNotifiedWarning: _isAlertAnUpdate(
@@ -77,10 +76,9 @@ Future<void> callAPI({
         );
       }
     }
-
-    // Update the state
-    warningService.set(updatedWarnings);
   }
+  // Update the state
+  warningService.set(updatedWarnings);
 
   // update status notification if the user wants
   if (userPreferences.showStatusNotification) {

--- a/lib/services/list_handler.dart
+++ b/lib/services/list_handler.dart
@@ -76,7 +76,7 @@ extension UpdateListEntry<T> on List<T> {
   /// Update a single element in a list
   /// [element] the element to update. Must be uniquely identifiable through the == operator
   List<T> updateEntry(T element) {
-    var index = indexOf(element);
+    int index = indexOf(element);
 
     return [
       ...sublist(0, index),

--- a/lib/services/list_handler.dart
+++ b/lib/services/list_handler.dart
@@ -7,7 +7,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../class/class_warn_message.dart';
 
 final cachedPlacesProvider = FutureProvider<List<Place>>((ref) async {
-  SharedPreferences preferences = await SharedPreferences.getInstance();
+  SharedPreferencesWithCache preferences =
+      await SharedPreferencesWithCache.create(
+    cacheOptions: const SharedPreferencesWithCacheOptions(),
+  );
 
   if (preferences.containsKey("MyPlacesListAsJson")) {
     List<dynamic> data =
@@ -48,7 +51,11 @@ class MyPlacesService extends StateNotifier<List<Place>> {
   }
 
   Future<void> set(List<Place> places) async {
-    SharedPreferences preferences = await SharedPreferences.getInstance();
+    SharedPreferencesWithCache preferences =
+        await SharedPreferencesWithCache.create(
+      cacheOptions: const SharedPreferencesWithCacheOptions(),
+    );
+
     preferences.setString("MyPlacesListAsJson", jsonEncode(places));
 
     if (!mounted) return;

--- a/lib/services/warnings.dart
+++ b/lib/services/warnings.dart
@@ -18,7 +18,7 @@ class WarningService extends StateNotifier<List<WarnMessage>> {
   final List<Place> places;
 
   List<WarnMessage> _sortWarnings(List<WarnMessage> warnings) {
-    var sortedWarnings = List<WarnMessage>.of(state);
+    List<WarnMessage> sortedWarnings = List<WarnMessage>.of(warnings);
 
     if (userPreferences.sortWarningsBy == SortingCategories.severity) {
       sortedWarnings.sort(
@@ -57,8 +57,8 @@ class WarningService extends StateNotifier<List<WarnMessage>> {
   }
 
   void updateWarning(WarnMessage warning) {
-    var warnings = List<WarnMessage>.from(state);
-    warnings.updateEntry(warning);
+    List<WarnMessage> warnings = List<WarnMessage>.from(state);
+    warnings = warnings.updateEntry(warning);
     state = _sortWarnings(warnings);
   }
 

--- a/lib/views/add_my_place_with_map_view.dart
+++ b/lib/views/add_my_place_with_map_view.dart
@@ -210,7 +210,7 @@ class _AddMyPlaceWithMapViewState extends ConsumerState<AddMyPlaceWithMapView> {
     );
     // create polygon around place
     selectedPlacePolygon = Polygon(
-      color: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
+      color: Theme.of(context).colorScheme.secondary.withValues(alpha: .5),
       points: circlePolygonPoints,
     );
   }
@@ -225,7 +225,7 @@ class _AddMyPlaceWithMapViewState extends ConsumerState<AddMyPlaceWithMapView> {
     );
     // create polygon around place
     selectedPlacePolygon = Polygon(
-      color: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
+      color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.5),
       points: points,
     );
   }
@@ -512,6 +512,7 @@ class _AddMyPlaceWithMapViewState extends ConsumerState<AddMyPlaceWithMapView> {
                               // setup unifiedPush
                               await UnifiedPushHandler.setupUnifiedPush(
                                 context,
+                                ref,
                               );
 
                               // subscribe for new area and create new place

--- a/lib/views/add_my_place_with_map_view.dart
+++ b/lib/views/add_my_place_with_map_view.dart
@@ -210,7 +210,7 @@ class _AddMyPlaceWithMapViewState extends ConsumerState<AddMyPlaceWithMapView> {
     );
     // create polygon around place
     selectedPlacePolygon = Polygon(
-      color: Theme.of(context).colorScheme.secondary.withValues(alpha: .5),
+      color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.5),
       points: circlePolygonPoints,
     );
   }

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -52,6 +52,8 @@ class _HomeViewState extends ConsumerState<HomeView> {
       ),
     );
 
+    UnifiedPushHandler.setupUnifiedPush(context, ref);
+
     NotificationService.onNotification.stream.listen(onClickedNotification);
   }
 

--- a/lib/views/introduction/introduction_view.dart
+++ b/lib/views/introduction/introduction_view.dart
@@ -187,7 +187,7 @@ class _PageProgressDots extends StatelessWidget {
                 decoration: BoxDecoration(
                   color: currentPage == index
                       ? const Color(0XFF256075)
-                      : const Color(0XFF256075).withOpacity(0.2),
+                      : const Color(0XFF256075).withValues(alpha: 0.2),
                   borderRadius: BorderRadius.circular(10.0),
                 ),
               ),

--- a/lib/views/warning_detail_view.dart
+++ b/lib/views/warning_detail_view.dart
@@ -229,8 +229,10 @@ class _DetailScreenState extends ConsumerState<DetailScreen> {
         );
       } else {
         return CameraFit.bounds(
-          // set the bounds to the northpol if we don't have any points
-          bounds: LatLngBounds.fromPoints([const LatLng(90.0, 0.0)]),
+          // set the bounds to the north pole if we don't have any points
+          bounds: LatLngBounds.fromPoints(
+            [const LatLng(90.0, 0.0), const LatLng(89.9, 0.1)],
+          ),
           padding: const EdgeInsets.all(30),
         );
       }
@@ -268,9 +270,9 @@ class _DetailScreenState extends ConsumerState<DetailScreen> {
         ),
       );
     } catch (e) {
-      return const SizedBox(
+      return SizedBox(
         height: 200,
-        child: Text("Errpr"),
+        child: Text("Error - failed to show map: $e"),
       );
     }
   }
@@ -279,14 +281,14 @@ class _DetailScreenState extends ConsumerState<DetailScreen> {
   void initState() {
     super.initState();
 
-    var warning = ref.read(warningsProvider).firstWhere(
-          (element) => element.identifier == widget.warningIdentifier,
-        );
-    ref
-        .read(warningsProvider.notifier)
-        .updateWarning(warning.copyWith(read: true));
-
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      var warning = ref.read(warningsProvider).firstWhere(
+            (element) => element.identifier == widget.warningIdentifier,
+          );
+      ref
+          .read(warningsProvider.notifier)
+          .updateWarning(warning.copyWith(read: true));
+
       // cancel the notification
       await NotificationService.cancelOneNotification(
         warning.identifier.hashCode,

--- a/lib/widgets/connection_error_widget.dart
+++ b/lib/widgets/connection_error_widget.dart
@@ -61,8 +61,7 @@ class ConnectionError extends StatelessWidget {
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   child: Text(
-                    'Ups. Something went wrong. Please contact the developer',
-                    // @todo translate app_error_message
+                    localizations.connection_error_app_error,
                     style: theme.textTheme.displaySmall,
                     overflow: TextOverflow.ellipsis,
                   ),

--- a/lib/widgets/dialogs/delete_place_dialog.dart
+++ b/lib/widgets/dialogs/delete_place_dialog.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/class/class_fpas_place.dart';
 import 'package:foss_warn/services/alert_api/fpas.dart';
 import 'package:foss_warn/extensions/context.dart';
+import 'package:foss_warn/services/api_handler.dart';
 import '../../services/update_provider.dart';
 
 class DeletePlaceDialog extends ConsumerWidget {
@@ -24,9 +26,17 @@ class DeletePlaceDialog extends ConsumerWidget {
 
       // Unsubscribe from server
       debugPrint("unregister from server for place ${myPlace.name}");
-      await alertApi.unregisterArea(
-        subscriptionId: myPlace.subscriptionId,
-      );
+      try {
+        await alertApi.unregisterArea(
+          subscriptionId: myPlace.subscriptionId,
+        );
+      } on UnregisterAreaError {
+        ErrorLogger.writeErrorLog(
+          "delete_place.dart",
+          "onDeletePlacePressed",
+          "Failed to delete subscription",
+        );
+      }
 
       updater.deletePlace(myPlace);
 

--- a/lib/widgets/dialogs/delete_place_dialog.dart
+++ b/lib/widgets/dialogs/delete_place_dialog.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:foss_warn/class/class_error_logger.dart';
 import 'package:foss_warn/class/class_fpas_place.dart';
 import 'package:foss_warn/services/alert_api/fpas.dart';
 import 'package:foss_warn/extensions/context.dart';
@@ -19,10 +18,10 @@ class DeletePlaceDialog extends ConsumerWidget {
 
     var updater = ref.read(updaterProvider);
     var alertApi = ref.read(alertApiProvider);
+    var scaffoldMessenger = ScaffoldMessenger.of(context);
 
     Future<void> onDeletePlacePressed() async {
-      //remove place from list and update view
-      debugPrint("place deleted");
+      // remove place from list and update view
 
       // Unsubscribe from server
       debugPrint("unregister from server for place ${myPlace.name}");
@@ -30,15 +29,20 @@ class DeletePlaceDialog extends ConsumerWidget {
         await alertApi.unregisterArea(
           subscriptionId: myPlace.subscriptionId,
         );
+        updater.deletePlace(myPlace);
       } on UnregisterAreaError {
-        ErrorLogger.writeErrorLog(
-          "delete_place.dart",
-          "onDeletePlacePressed",
-          "Failed to delete subscription",
+        // we currently can not unsubscribe - show a snack bar to inform the
+        // user to check their internet connection
+        final snackBar = SnackBar(
+          content: Text(
+            localizations.delete_place_error,
+            style: TextStyle(color: theme.colorScheme.onErrorContainer),
+          ),
+          backgroundColor: theme.colorScheme.errorContainer,
         );
-      }
 
-      updater.deletePlace(myPlace);
+        scaffoldMessenger.showSnackBar(snackBar);
+      }
 
       if (!context.mounted) return;
       navigator.pop();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,42 +13,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cross_file:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -233,18 +233,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -281,10 +281,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -321,10 +321,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -513,15 +513,15 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -534,10 +534,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   state_notifier:
     dependency: transitive
     description:
@@ -550,34 +550,34 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.4"
   timezone:
     dependency: transitive
     description:
@@ -606,26 +606,26 @@ packages:
     dependency: "direct main"
     description:
       name: unifiedpush
-      sha256: "6dbed5a6305ca33f1865c7a3d814ae39476b79a2d23ca76a5708f023f405730f"
+      sha256: e72bdccaad51687c8ab84dc894bdf2bfbd0fda0bde23c932fcb1fb800c73e752
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.0-rc2"
   unifiedpush_android:
     dependency: transitive
     description:
       name: unifiedpush_android
-      sha256: "7443dece0a850ae956514f809983eb2b39fc518c2c7d24dbfe817198bec89134"
+      sha256: fbe6754a1e0ed50779ccff4d72cf5a71a9c903c544f08b4f8a2f1d02086245b8
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.0-rc2"
   unifiedpush_platform_interface:
     dependency: transitive
     description:
       name: unifiedpush_platform_interface
-      sha256: dd588d78a8b2bfc10430e30035526e98caa543d0b7364a6344b5eb4815721c6d
+      sha256: "03bd562c59bd6b952c0e49f5fe07c15e01c098717d5b3fc98a46d3d9090d8c4a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.0-rc2"
   url_launcher:
     dependency: "direct main"
     description:
@@ -734,10 +734,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -787,5 +787,5 @@ packages:
     source: hosted
     version: "6.2.5"
 sdks:
-  dart: ">=3.5.4 <3.13.3"
+  dart: ">=3.7.0-0 <3.13.3"
   flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   url_launcher: ^6.3.1
   share_plus: ^10.1.1
   intl: any # for localizations
-  unifiedpush: ^5.0.2
+  unifiedpush: ^6.0.0-rc2
   xml2json: ^6.2.5
 
   # used by the map


### PR DESCRIPTION
this updates to the UnifiedPush 6.0.0rc2 and adds support for webpush. If the server instance supports webpush and the client can successfully fetch the VAPID key, we will now use encrypted UnifiedPush as the default. If the instance does not support webpush yet or we can not get a valid auth and p256 key, we will use unencrypted unifiedPush as a fallback.