### PR TITLE
fix: sort the new warnings rather than the old state

### DIFF
--- a/lib/services/alert_api/fpas.dart
+++ b/lib/services/alert_api/fpas.dart
@@ -62,6 +62,10 @@ class FPASApi implements AlertAPI {
       },
     );
 
+    if (response.statusCode != 200) {
+      throw UnreachableServerError();
+    }
+
     return List<String>.from(jsonDecode(utf8.decode(response.bodyBytes)));
   }
 
@@ -80,6 +84,10 @@ class FPASApi implements AlertAPI {
         'User-Agent': constants.httpUserAgent,
       },
     );
+
+    if (response.statusCode != 200) {
+      throw UnreachableServerError();
+    }
 
     var xml2jsonTransformer = Xml2Json();
     xml2jsonTransformer.parse(utf8.decode(response.bodyBytes));

--- a/lib/services/api_handler.dart
+++ b/lib/services/api_handler.dart
@@ -24,6 +24,7 @@ Future<void> callAPI({
 
   await loadMyPlacesList();
 
+  var updatedWarnings = <WarnMessage>[];
   for (Place place in places) {
     var alertIds =
         await alertApi.getAlerts(subscriptionId: place.subscriptionId);
@@ -36,7 +37,6 @@ Future<void> callAPI({
       ],
     ]);
 
-    var updatedWarnings = <WarnMessage>[];
     for (var warning in warnings) {
       updatedWarnings.add(
         warning.copyWith(
@@ -62,10 +62,10 @@ Future<void> callAPI({
         );
       }
     }
-
-    // Update the state
-    warningService.set(updatedWarnings);
   }
+
+  // Update the state
+  warningService.set(updatedWarnings);
 
   // update status notification if the user wants
   if (userPreferences.showStatusNotification) {

--- a/lib/services/warnings.dart
+++ b/lib/services/warnings.dart
@@ -18,7 +18,7 @@ class WarningService extends StateNotifier<List<WarnMessage>> {
   final List<Place> places;
 
   List<WarnMessage> _sortWarnings(List<WarnMessage> warnings) {
-    var sortedWarnings = List<WarnMessage>.of(state);
+    var sortedWarnings = List<WarnMessage>.of(warnings);
 
     if (userPreferences.sortWarningsBy == SortingCategories.severity) {
       sortedWarnings.sort(

--- a/lib/views/warning_detail_view.dart
+++ b/lib/views/warning_detail_view.dart
@@ -279,14 +279,14 @@ class _DetailScreenState extends ConsumerState<DetailScreen> {
   void initState() {
     super.initState();
 
-    var warning = ref.read(warningsProvider).firstWhere(
-          (element) => element.identifier == widget.warningIdentifier,
-        );
-    ref
-        .read(warningsProvider.notifier)
-        .updateWarning(warning.copyWith(read: true));
-
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      var warning = ref.read(warningsProvider).firstWhere(
+            (element) => element.identifier == widget.warningIdentifier,
+          );
+      ref
+          .read(warningsProvider.notifier)
+          .updateWarning(warning.copyWith(read: true));
+
       // cancel the notification
       await NotificationService.cancelOneNotification(
         warning.identifier.hashCode,


### PR DESCRIPTION
The passed warnings to _sortWarnings were being ignored and instead the previous state was taken. However on a clean app launch the previous state would be an empty list, thus results would never end up in the state.