### PR TITLE
Use singular of "There are" in English translation

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -415,6 +415,8 @@
   "@explanation_warning_level_all_clear_text": {},
   "my_place_there_are": "There are",
   "@my_place_there_are": {},
+  "my_place_there_is": "There is",
+  "@my_place_there_is": {},
   "my_place_warnings_more_then_one": "warnings",
   "@my_place_warnings_more_then_one": {},
   "my_place_warnings_only_one": "warning",

--- a/lib/widgets/MyPlaceWidget.dart
+++ b/lib/widgets/MyPlaceWidget.dart
@@ -20,7 +20,7 @@ class MyPlaceWidget extends StatelessWidget {
             " " +
             AppLocalizations.of(context)!.my_place_warnings_more_then_one;
       } else {
-        return AppLocalizations.of(context)!.my_place_there_are +
+        return AppLocalizations.of(context)!.my_place_there_is +
             " " +
             myPlace.countWarnings.toString() +
             " " +


### PR DESCRIPTION
In the English version of FossWarn, My places displays "There are 1 warning" when it should be "There is 1 warning" instead. I haven't worked with Weblate that much before, so please correct me if this is the wrong way of adding a new key for translation.

PS: Thank you very much for the wonderful app!
PPS: German and French translation seem to be fine as they use a generic "Es gibt"/"Il y en", so they probably just need to use the same string as "my_place_there_are". I don't know about the other languages.