### PR TITLE
Fix alert parsing

### DIFF
--- a/lib/views/warning_detail_view.dart
+++ b/lib/views/warning_detail_view.dart
@@ -41,10 +41,11 @@ List<String> _generateAreaDescriptionList({
   return result;
 }
 
-// @todo think about moving code to better place
+// @TODO(Nucleus) think about moving code to better place and think about replacing this with something better
 String _replaceHTMLTags(String text) {
   String replacedText = text;
   replacedText = replacedText.replaceAll("<br/>", "\n");
+  replacedText = replacedText.replaceAll("<br />", "\n");
   replacedText = replacedText.replaceAll("<br>", "\n");
   replacedText = replacedText.replaceAll("br>", "\n");
   replacedText = replacedText.replaceAll("&nbsp;", " ");


### PR DESCRIPTION
Some alerts use `<br \>` as HTML tag. Currently, this results in a parsing error. Replacing them with `\n` solves the issue.