### PR TITLE
fix(legacy handler): use the version constant rather than getting it from preferences

### DIFF
--- a/lib/services/legacy_handler.dart
+++ b/lib/services/legacy_handler.dart
@@ -42,12 +42,12 @@ Future<void> legacyHandler() async {
     prevVersion = preferences.getInt("previousInstalledVersionCode") ?? -1;
   } else {
     // new installation
-    prevVersion = preferences.getInt("currentVersionCode")!;
+    prevVersion = UserPreferences.currentVersionCode;
     successfullyUpdated = true;
   }
 
   // @todo check for version < 0.8.0 because of new structured alerts
-  if (prevVersion < 32) {
+  if (prevVersion < UserPreferences.currentVersionCode) {
     try {
       allAvailablePlacesNames = [];
       preferences.remove("geocodes");


### PR DESCRIPTION
On new installations there are no preferences yet to retrieve anything from so expecting values from exist from there causes null check errors.