### PR TITLE
Set distinct version codes for ABIs to comply with the F-Droid schema

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -98,3 +98,18 @@ dependencies {
     // for flutter_local_notification plugin
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.0.4"
 }
+
+// The following code creates a mapping that assigns a unique numeric value for each ABI
+// and overrides the output version code.
+//
+// See https://developer.android.com/build/configure-apk-splits#configure-APK-versions
+ext.abiCodes = ["x86_64": 1, "armeabi-v7a": 2, "arm64-v8a": 3]
+import com.android.build.OutputFile
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def abiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        if (abiVersionCode != null) {
+            output.versionCodeOverride = variant.versionCode * 10 + abiVersionCode
+        }
+    }
+}


### PR DESCRIPTION
Currently the universal APK is used on F-Droid: https://f-droid.org/en/packages/de.nucleus.foss_warn. However, ABI-specific APKs are provided in the GitHub Release.

To distribute ABI-specific APKs on F-Droid, distinct version codes need to be configured for different ABIs.

Refer to https://developer.android.com/build/configure-apk-splits#configure-APK-versions for further information.