### PR TITLE
Fix the flickering alert due to a constantly overridden alert

### DIFF
--- a/lib/class/class_warn_message.dart
+++ b/lib/class/class_warn_message.dart
@@ -175,10 +175,12 @@ class WarnMessage {
 
     // An alert is only the same if the ID and the subscription ID are the same.
     // We can have one alert for multiple places
-    return other.identifier == identifier &&
+    // The identifier should be unique, but in reality, it isn't, so we have to
+    // use the FPAS ID for identification.
+    return other.fpasId == fpasId &&
         other.placeSubscriptionId == placeSubscriptionId;
   }
 
   @override
-  int get hashCode => identifier.hashCode;
+  int get hashCode => fpasId.hashCode;
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -135,7 +135,7 @@ final routesProvider = Provider<GoRouter>(
                   String subscriptionId =
                       state.pathParameters["subscriptionId"]!;
                   return DetailScreen(
-                    warningIdentifier: id,
+                    warningFPASIdentifer: id,
                     subscriptionId: subscriptionId,
                   );
                 },
@@ -143,8 +143,8 @@ final routesProvider = Provider<GoRouter>(
               GoRoute(
                 path: 'update',
                 builder: (context, state) => AlertUpdateThreadView(
-                  onAlertPressed: (alertId, subscriptionId) =>
-                      context.go('/alerts/$alertId/$subscriptionId'),
+                  onAlertPressed: (fpasAlertId, subscriptionId) =>
+                      context.go('/alerts/$fpasAlertId/$subscriptionId'),
                   onAlertUpdateThreadPressed: () =>
                       context.go('/alerts/update'),
                 ),

--- a/lib/services/notification_handler.dart
+++ b/lib/services/notification_handler.dart
@@ -81,7 +81,7 @@ Future<void> newAlertNotification(
         userPreferences,
       )) {
         NotificationService.showNotification(
-          id: alert.identifier.hashCode,
+          id: alert.fpasId.hashCode,
           title: "New alert",
           body: alert.info.first.headline,
           payload: "",

--- a/lib/services/warnings.dart
+++ b/lib/services/warnings.dart
@@ -285,7 +285,7 @@ void showNotification(
       NotificationService.showNotification(
         // generate from the warning in the List the notification id
         // because the warning identifier is no int, we have to generate a hash code
-        id: warning.identifier.hashCode,
+        id: warning.fpasId.hashCode,
         title: localisations.notification_alert_new_title(place.name),
         body: warning.info[0].headline,
         payload: place.name,

--- a/lib/views/alert_update_thread_view.dart
+++ b/lib/views/alert_update_thread_view.dart
@@ -24,7 +24,7 @@ class AlertUpdateThreadView extends ConsumerStatefulWidget {
     super.key,
   });
 
-  final void Function(String alertId, String subscriptionId) onAlertPressed;
+  final void Function(String fpasAlertId, String subscriptionId) onAlertPressed;
   final void Function() onAlertUpdateThreadPressed;
 
   @override

--- a/lib/views/my_place_detail_view.dart
+++ b/lib/views/my_place_detail_view.dart
@@ -61,7 +61,6 @@ class MyPlaceDetailScreen extends ConsumerWidget {
             for (var alWm in warnings) {
               debugPrint(alWm.identifier);
               if (alWm.identifier.compareTo(id) == 0) {
-                //print("found referenced alert: ${alWm.identifier}");
                 // check if alert is already in the thread
                 if (!oneUpdateThread
                     .any((element) => element.identifier == alWm.identifier)) {

--- a/lib/views/warning_detail_view.dart
+++ b/lib/views/warning_detail_view.dart
@@ -218,11 +218,11 @@ List<Widget> _generateAssets(String text, {required BuildContext context}) {
 }
 
 class DetailScreen extends ConsumerStatefulWidget {
-  final String warningIdentifier;
+  final String warningFPASIdentifer;
   final String subscriptionId;
 
   const DetailScreen({
-    required this.warningIdentifier,
+    required this.warningFPASIdentifer,
     required this.subscriptionId,
     super.key,
   });
@@ -241,7 +241,7 @@ class _DetailScreenState extends ConsumerState<DetailScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       var warning = ref.read(processedAlertsProvider).firstWhere(
             (alert) =>
-                alert.identifier == widget.warningIdentifier &&
+                alert.fpasId == widget.warningFPASIdentifer &&
                 alert.placeSubscriptionId == widget.subscriptionId,
           );
 
@@ -273,7 +273,7 @@ class _DetailScreenState extends ConsumerState<DetailScreen> {
     WarnMessage warning = ref.watch(
       processedAlertsProvider.select(
         (value) => value.firstWhere(
-          (element) => element.identifier == widget.warningIdentifier,
+          (element) => element.fpasId == widget.warningFPASIdentifer,
         ),
       ),
     );

--- a/lib/widgets/warning_widget.dart
+++ b/lib/widgets/warning_widget.dart
@@ -88,7 +88,7 @@ class WarningWidget extends ConsumerWidget {
     return Card(
       child: InkWell(
         onTap: () => onAlertPressed(
-          _warnMessage.identifier,
+          _warnMessage.fpasId,
           _warnMessage.placeSubscriptionId,
         ),
         child: Padding(
@@ -192,7 +192,7 @@ class WarningWidget extends ConsumerWidget {
                 children: [
                   IconButton(
                     onPressed: () => onAlertPressed(
-                      _warnMessage.identifier,
+                      _warnMessage.fpasId,
                       _warnMessage.placeSubscriptionId,
                     ),
                     icon: const Icon(Icons.read_more),


### PR DESCRIPTION
 Fix the flickering alert due to a constantly overridden alert caused by multiple alerts with the same identifier. We are now using the FPAS ID instead of the CAP ID.

fix #269 