### PR TITLE
Remove non-free components of Geolocator_android

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,26 +225,27 @@ packages:
     dependency: "direct main"
     description:
       name: geolocator
-      sha256: "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516"
+      sha256: e146a6d63776582651e97a79cbe459f8e1211b100101fadcd84db83361fa599f
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.2"
+    version: "14.0.3"
   geolocator_android:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: geolocator_android
-      sha256: "179c3cb66dfa674fc9ccbf2be872a02658724d1c067634e2c427cf6df7df901a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.2"
+      path: geolocator_android
+      ref: "969e51c0ff1fea1053e590b34c6f0930652d321f"
+      resolved-ref: "969e51c0ff1fea1053e590b34c6f0930652d321f"
+      url: "https://github.com/nucleus-ffm/flutter-geolocator.git"
+    source: git
+    version: "5.0.3"
   geolocator_apple:
     dependency: transitive
     description:
       name: geolocator_apple
-      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      sha256: "853803d6bb1713c094e935b4a5ae5f19c0308acf81da13fa9ff84fb4c70c0b73"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.13"
+    version: "2.3.14"
   geolocator_linux:
     dependency: transitive
     description:
@@ -265,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: geolocator_web
-      sha256: b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172
+      sha256: "19e485a0f8d6a88abcf9c53cba3a4105e14b7435ed8ac1c108c067b938fe8429"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.3"
+    version: "4.1.4"
   geolocator_windows:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,22 @@ dependencies:
   permission_handler: ^12.0.1
   permission_handler_android: ^13.0.1
   permission_handler_platform_interface: ^4.3.0
-  geolocator: ^14.0.2
+  geolocator: ^14.0.3
+
+# geolocator_android depends on com.google.android.gms:play-services-location,
+# which is non-free and makes F-Droid refuse to build the app. Excluding the
+# artifact via Gradle does not work — the classes still end up in the APK, see
+# https://github.com/Baseflow/flutter-geolocator/issues/1481
+#
+# The fork below removes the fused location provider so the plugin always uses
+# the AOSP LocationManager. It is pinned by commit and kept
+# in sync with upstream by a workflow in that repository.
+dependency_overrides:
+  geolocator_android:
+    git:
+      url: https://github.com/nucleus-ffm/flutter-geolocator.git
+      path: geolocator_android
+      ref: 969e51c0ff1fea1053e590b34c6f0930652d321f
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This overrides the geolocator_android dependency with a forked version that removes the non-free components. This is required for F-Droid.